### PR TITLE
Remove variant from omitted text field properties for select element

### DIFF
--- a/src/SelectElement.tsx
+++ b/src/SelectElement.tsx
@@ -2,7 +2,7 @@ import React, { createElement } from 'react'
 import { MenuItem, TextField, TextFieldProps } from '@material-ui/core'
 import { Controller, ControllerProps, FieldError } from 'react-hook-form'
 
-export type SelectElementProps = Omit<TextFieldProps, 'name' | 'variant' | 'type' | 'onChange'> & {
+export type SelectElementProps = Omit<TextFieldProps, 'name' | 'type' | 'onChange'> & {
   validation?: ControllerProps['rules']
   name: string
   options?: any[]

--- a/stories/SelectElement.stories.tsx
+++ b/stories/SelectElement.stories.tsx
@@ -49,6 +49,19 @@ export const Basic = () => {
         onChange={action('change')}
         objectOnChange
       /><br />
+      <SelectElement
+        className={classes.formControl}
+        value="Basic Select"
+        variant="outlined"
+        required
+        parseError={() => {
+          return 'This field is required'
+        }}
+        label={text('label', 'Outlined select')}
+        name="pre-select-element"
+        options={object('Options', [{ id: '1', title: 'Label 1' }, { id: '2', title: 'label 2' }])}
+        onChange={action('change')}
+      /><br />
       <Button type={'submit'} color={'primary'}>Submit</Button>
     </FormContainer>
   )


### PR DESCRIPTION
Current typing causes type errors when attempting to customize the variant on the Select element. 