### PR TITLE
Explicit ParseableDate type instead of importing from lab

### DIFF
--- a/src/DatePickerElement.tsx
+++ b/src/DatePickerElement.tsx
@@ -1,8 +1,15 @@
 import React from 'react'
 import { DatePicker, DatePickerProps } from '@mui/lab'
 import { Control, Controller, ControllerProps, FieldError } from 'react-hook-form'
-import { ParseableDate } from '@mui/lab/internal/pickers/constants/prop-types'
 import { TextField, TextFieldProps } from '@mui/material'
+
+export declare type ParseableDate<TDate> =
+  | string
+  | number
+  | Date
+  | null
+  | undefined
+  | TDate;
 
 export type DatePickerElementProps<TDate = unknown> = Omit<DatePickerProps, 'value' | 'onChange' | 'renderInput'> & {
   name: string


### PR DESCRIPTION
Explicit declaration of ParseableDate type.

On latest version importing type is not working anymore.

I believe this will be better as it is a simple type and the date picker is still in lab.

```typescript
export declare type ParseableDate<TDate> =
  | string
  | number
  | Date
  | null
  | undefined
  | TDate;
```