### PR TITLE
fix: 🐛 use PropsWithChildren for FormContainerProps type

### DIFF
--- a/src/FormContainer.tsx
+++ b/src/FormContainer.tsx
@@ -1,13 +1,13 @@
-import React, { FormHTMLAttributes, FunctionComponent } from 'react'
+import React, { FormHTMLAttributes, FunctionComponent, PropsWithChildren } from 'react'
 import { FormProvider, useForm, UseFormReturn } from 'react-hook-form'
 
-export type FormContainerProps = {
+export type FormContainerProps = PropsWithChildren<{
   defaultValues?: any
   onSuccess?: (values: any) => void
   handleSubmit?: (values: any) => void
   formContext?: UseFormReturn<any>
   FormProps?: FormHTMLAttributes<HTMLFormElement>
-}
+}>
 
 const FormContainerCore: FunctionComponent<FormContainerProps> = ({
   defaultValues = {},


### PR DESCRIPTION
The children prop was not defined on `FormContainerProps` resulting in type errors when rendering a `FormContainer` with `children`. 