### PR TITLE
mod: enable setting of icon color for visibility icons from palette

### DIFF
--- a/src/PasswordElement.tsx
+++ b/src/PasswordElement.tsx
@@ -1,12 +1,14 @@
 import { MouseEvent, useState } from 'react'
 import TextFieldElement, { TextFieldElementProps } from './TextFieldElement'
-import { IconButton, InputAdornment } from '@mui/material'
+import { IconButton, IconButtonProps, InputAdornment } from '@mui/material'
 import Visibility from '@mui/icons-material/Visibility'
 import VisibilityOff from '@mui/icons-material/VisibilityOff'
 
-export type PasswordElementProps = TextFieldElementProps
+export type PasswordElementProps = TextFieldElementProps & {
+  iconColor?: IconButtonProps['color']
+}
 
-export default function PasswordElement(props: PasswordElementProps): JSX.Element {
+export default function PasswordElement({iconColor, ...props}: PasswordElementProps): JSX.Element {
   const [password, setPassword] = useState<boolean>(true)
   return (
     <TextFieldElement
@@ -20,6 +22,7 @@ export default function PasswordElement(props: PasswordElementProps): JSX.Elemen
               }
               onClick={() => setPassword(!password)}
               tabIndex={-1}
+              color={iconColor ?? 'default'}
             >
               {password ? <Visibility /> : <VisibilityOff />}
             </IconButton>


### PR DESCRIPTION
As written in #41 this will allow to set the color of the Adornment Icon.

I tested also to allow "start" position for Adornment but that makes no sense, so iconColor is only useful prop.