### PR TITLE
[bugfix] renderedInput not resetting upon formContext.reset()

### DIFF
--- a/src/DatePickerElement.tsx
+++ b/src/DatePickerElement.tsx
@@ -66,18 +66,29 @@ export default function DatePickerElement({
             }
           }}
           renderInput={
-            (params) =>
-              <TextField
-                {...params}
-                {...inputProps}
-                required={!!required}
-                error={invalid}
-                helperText={
-                  error
-                    ? (typeof parseError === 'function' ? parseError(error) : error.message)
-                    : inputProps?.helperText || rest.helperText
-                }
-              />
+            (params) => {
+              const tempParams = { ...params };
+              if (!value) {
+                tempParams["inputProps"] = {
+                  ...tempParams["inputProps"],
+                  value: "",
+                };
+              }
+              
+              return (
+                <TextField
+                  {...tempParams}
+                  {...inputProps}
+                  required={!!required}
+                  error={invalid}
+                  helperText={
+                    error
+                      ? (typeof parseError === 'function' ? parseError(error) : error.message)
+                      : inputProps?.helperText || rest.helperText
+                  }
+                />
+              )
+            }
           }
         />}
     />


### PR DESCRIPTION
I really love the react-hook-form-mui but I have encountered a bug where the DatePickerElement does not reset when reset({}) from a useForm() is invoked. This is a solution I have come up with and is currently using on my current project.