### PR TITLE
fix overriding custom validation properties

### DIFF
--- a/src/CheckboxElement.tsx
+++ b/src/CheckboxElement.tsx
@@ -29,7 +29,7 @@ export default function CheckboxElement({
   ...rest
 }: CheckboxElementProps): JSX.Element {
 
-  if (required) {
+  if (required && !validation.required) {
     validation.required = 'This field is required'
   }
 

--- a/src/DatePickerElement.tsx
+++ b/src/DatePickerElement.tsx
@@ -35,7 +35,7 @@ export default function DatePickerElement({
   ...rest
 }: DatePickerElementProps): JSX.Element {
 
-  if (required) {
+  if (required && !validation.required) {
     validation.required = 'This field is required'
   }
 

--- a/src/MultiSelectElement.tsx
+++ b/src/MultiSelectElement.tsx
@@ -55,7 +55,7 @@ export default function MultiSelectElement({
   ...rest
 }: MultiSelectElementProps): JSX.Element {
 
-  if (required) {
+  if (required && !validation.required) {
     validation.required = 'This field is required'
   }
 

--- a/src/SelectElement.tsx
+++ b/src/SelectElement.tsx
@@ -30,9 +30,11 @@ export default function SelectElement({
 }: SelectElementProps): JSX.Element {
   const isNativeSelect = !!rest.SelectProps?.native
   const ChildComponent = isNativeSelect ? 'option' : MenuItem
-  if (required) {
+
+  if (required && !validation.required) {
     validation.required = 'This field is required'
   }
+
   return (
     <Controller
       name={name}

--- a/src/TextFieldElement.tsx
+++ b/src/TextFieldElement.tsx
@@ -18,16 +18,19 @@ export default function TextFieldElement({
   control,
   ...rest
 }: TextFieldElementProps): JSX.Element {
-  if (required) {
+
+  if (required && !validation.required) {
     validation.required = 'This field is required'
   }
-  if (type === 'email') {
+
+  if (type === 'email' && !validation.pattern) {
     validation.pattern = {
       // eslint-disable-next-line no-useless-escape
       value: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
       message: 'Please enter a valid email address'
     }
   }
+
   return (
     <Controller
       name={name}

--- a/stories/DatePickerElement.stories.tsx
+++ b/stories/DatePickerElement.stories.tsx
@@ -33,3 +33,11 @@ Required.args = {
   name: 'required',
   required: true
 }
+
+export const RequiredCustomMessage = Template.bind({})
+RequiredCustomMessage.args = {
+  label: 'Required Picker',
+  name: 'requiredCustomMessage',
+  required: true,
+  validation: { required: 'Custom required message' }
+}


### PR DESCRIPTION
This fix prevents overriding custom validation messages and settings due to standard values like "This field is required".

Checkout new Story Template for RequiredCustomMessage with and without patch.

Attn: I made this update on 3.6 sources - There were some missing dependencies from storybook and vite which I did not checked in. Best you merge by your decision.