### PR TITLE
Autocomplete Element: Fix Option Clearing

### DIFF
--- a/src/AutocompleteElement.tsx
+++ b/src/AutocompleteElement.tsx
@@ -69,7 +69,7 @@ export default function AutocompleteElement({
           onChange={(event, value, reason, details) => {
             const v = (Array.isArray(value)) ?
               value.map((i: any) => i?.id || i)
-              : value.id || value
+              : value?.id || value
             field.onChange(v)
             if (autocompleteProps?.onChange) {
               autocompleteProps.onChange(event, value, reason, details)


### PR DESCRIPTION
The `AutocompleteElement` (with or without the `required` option) will throw an error in the console when a user attempts to use the X to clear the field. This is due to the fact that a null value is being passed to the `onChange` function, which can't handle it properly. This quick fix allows it to work as intended.