### PR TITLE
Fixes #82: Use InputProps in AutocompleteElement

### DIFF
--- a/src/AutocompleteElement.tsx
+++ b/src/AutocompleteElement.tsx
@@ -110,7 +110,7 @@ export default function AutocompleteElement<TFieldValues extends FieldValues>({
                 error={!!error}
                 InputProps={{
                   ...params.InputProps,
-                  ...textFieldProps.InputProps
+                  ...textFieldProps.InputProps,
                   endAdornment: (
                     <>
                       {loading ? <CircularProgress color="inherit" size={20}/> : null}

--- a/src/AutocompleteElement.tsx
+++ b/src/AutocompleteElement.tsx
@@ -105,15 +105,16 @@ export default function AutocompleteElement<TFieldValues extends FieldValues>({
               <TextField name={name}
                 required={rules?.required ? true : required}
                 label={label}
-                {...textFieldProps}
                 {...params}
+                {...textFieldProps}
                 error={!!error}
                 InputProps={{
                   ...params.InputProps,
+                  ...textFieldProps.InputProps
                   endAdornment: (
                     <>
                       {loading ? <CircularProgress color="inherit" size={20}/> : null}
-                      {params.InputProps.endAdornment}
+                      {textFieldProps.InputProps.endAdornment}
                     </>
                   )
                 }}


### PR DESCRIPTION
The InputProps passed into the AutocompleteElement were not being applied, this PR should fix that issue.

Please test before merging as I was unable to build the package locally to do so myself.