### PR TITLE
Fix textFieldProps on AutocompleteElement

### DIFF
--- a/src/AutocompleteElement.tsx
+++ b/src/AutocompleteElement.tsx
@@ -105,8 +105,8 @@ export default function AutocompleteElement<TFieldValues extends FieldValues>({
               <TextField name={name}
                 required={rules?.required ? true : required}
                 label={label}
-                {...textFieldProps}
                 {...params}
+                {...textFieldProps}
                 error={!!error}
                 InputProps={{
                   ...params.InputProps,


### PR DESCRIPTION
Reason: passing lowercase `inputProps` to the `textFieldProps` of an AutocompleteElement still doesn't work. E.g., setting a maxLength has no effect.