### PR TITLE
Fix error focus on submit not working #102

### DIFF
--- a/packages/rhf-mui/src/AutocompleteElement.tsx
+++ b/packages/rhf-mui/src/AutocompleteElement.tsx
@@ -1,4 +1,4 @@
-import {Control, Controller, ControllerProps, Path} from 'react-hook-form'
+import {Control, Controller, ControllerProps, Path, useFormContext} from 'react-hook-form'
 import {Autocomplete, AutocompleteProps, Checkbox, TextField, TextFieldProps} from '@mui/material'
 import CircularProgress from '@mui/material/CircularProgress'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
@@ -43,6 +43,9 @@ export default function AutocompleteElement<TFieldValues extends FieldValues>({
             required: rules?.required || 'This field is required'
         })
     }
+
+    const { register } = useFormContext()
+
     return (
         <Controller
             name={name}
@@ -126,6 +129,7 @@ export default function AutocompleteElement<TFieldValues extends FieldValues>({
                             />
                         )}
                         {...fieldRest}
+                        ref={register(name).ref}
                     />
                 )
             }}/>

--- a/packages/rhf-mui/src/CheckboxButtonGroup.tsx
+++ b/packages/rhf-mui/src/CheckboxButtonGroup.tsx
@@ -8,7 +8,7 @@ import {
   FormLabel,
   useTheme
 } from '@mui/material'
-import {Control, FieldError, Path, useController} from 'react-hook-form'
+import {Control, FieldError, Path, useController, useFormContext} from 'react-hook-form'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 
 export type CheckboxButtonGroupProps<T extends FieldValues> = {
@@ -78,6 +78,8 @@ export default function CheckboxButtonGroup<TFieldValues extends FieldValues>({
         }
     }
 
+    const { register } = useFormContext()
+
     return (
         <FormControl error={invalid} required={required}>
             {label && <FormLabel error={invalid}>{label}</FormLabel>}
@@ -106,6 +108,7 @@ export default function CheckboxButtonGroup<TFieldValues extends FieldValues>({
                                     checked={isChecked}
                                     disabled={disabled}
                                     onChange={() => handleChange(optionKey)}
+                                    ref={register(name).ref}
                                 />
                             }
                             label={option[labelKey]}

--- a/packages/rhf-mui/src/CheckboxElement.tsx
+++ b/packages/rhf-mui/src/CheckboxElement.tsx
@@ -1,4 +1,4 @@
-import {Control, Controller, ControllerProps, FieldError, Path} from 'react-hook-form'
+import {Control, Controller, ControllerProps, FieldError, Path, useFormContext} from 'react-hook-form'
 import {
     Checkbox,
     CheckboxProps,
@@ -34,6 +34,8 @@ export default function CheckboxElement<TFieldValues extends FieldValues>({
         validation.required = 'This field is required'
     }
 
+    const { register } = useFormContext()
+
     return (
         <Controller
             name={name}
@@ -59,6 +61,7 @@ export default function CheckboxElement<TFieldValues extends FieldValues>({
                                         onChange={() => {
                                             onChange(!value)
                                         }}
+                                        ref={register(name).ref}
                                     />
                                 }
                             />

--- a/packages/rhf-mui/src/DatePickerElement.tsx
+++ b/packages/rhf-mui/src/DatePickerElement.tsx
@@ -1,5 +1,5 @@
 import {DatePicker, DatePickerProps} from '@mui/x-date-pickers/DatePicker'
-import {Control, Controller, ControllerProps, FieldError, Path} from 'react-hook-form'
+import {Control, Controller, ControllerProps, FieldError, Path, useFormContext} from 'react-hook-form'
 import {TextField, TextFieldProps} from '@mui/material'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 
@@ -45,6 +45,8 @@ export default function DatePickerElement<TFieldValues extends FieldValues>({
     validation.required = 'This field is required'
   }
 
+  const { register } = useFormContext()
+
   return (
     <Controller
       name={name}
@@ -81,6 +83,7 @@ export default function DatePickerElement<TFieldValues extends FieldValues>({
           renderInput={(params) => (
             <TextField
               {...params}
+              ref={register(name).ref}
               inputProps={{
                 ...params?.inputProps,
                 ...(!value && {

--- a/packages/rhf-mui/src/DateTimePickerElement.tsx
+++ b/packages/rhf-mui/src/DateTimePickerElement.tsx
@@ -1,5 +1,5 @@
 import {DateTimePicker, DateTimePickerProps} from '@mui/x-date-pickers/DateTimePicker'
-import {Control, Controller, ControllerProps, FieldError, Path} from 'react-hook-form'
+import {Control, Controller, ControllerProps, FieldError, Path, useFormContext} from 'react-hook-form'
 import {TextField, TextFieldProps} from '@mui/material'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 
@@ -45,6 +45,8 @@ export default function DateTimePickerElement<TFieldValues extends FieldValues>(
     validation.required = 'This field is required'
   }
 
+  const { register } = useFormContext()
+
   return (
     <Controller
       name={name}
@@ -80,6 +82,7 @@ export default function DateTimePickerElement<TFieldValues extends FieldValues>(
           renderInput={(params) => (
             <TextField
               {...params}
+              ref={register(name).ref}
               inputProps={{
                 ...params?.inputProps,
                 ...(!value && {

--- a/packages/rhf-mui/src/MultiSelectElement.tsx
+++ b/packages/rhf-mui/src/MultiSelectElement.tsx
@@ -1,5 +1,5 @@
 import CloseIcon from '@mui/icons-material/Cancel'
-import {Control, Controller, FieldError, Path} from 'react-hook-form'
+import {Control, Controller, FieldError, Path, useFormContext} from 'react-hook-form'
 import {
     Checkbox,
     Chip,
@@ -62,6 +62,8 @@ export default function MultiSelectElement<TFieldValues extends FieldValues>({
         validation.required = 'This field is required'
     }
 
+    const { register } = useFormContext()
+
     return (
         <Controller
             name={name}
@@ -99,6 +101,7 @@ export default function MultiSelectElement<TFieldValues extends FieldValues>({
                             required={required}
                             onChange={onChange}
                             onBlur={onBlur}
+                            ref={register(name).ref}
                             MenuProps={{
                                 ...rest.MenuProps,
                                 PaperProps: {

--- a/packages/rhf-mui/src/RadioButtonGroup.tsx
+++ b/packages/rhf-mui/src/RadioButtonGroup.tsx
@@ -1,5 +1,5 @@
 import {ChangeEvent} from 'react'
-import {Control, FieldError, Path, useController} from 'react-hook-form'
+import {Control, FieldError, Path, useController, useFormContext} from 'react-hook-form'
 import {FormControl, FormControlLabel, FormHelperText, FormLabel, Radio, RadioGroup, useTheme} from '@mui/material'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 
@@ -57,10 +57,13 @@ export default function RadioButtonGroup<TFieldValues extends FieldValues>({
         }
     }
 
+    const { register } = useFormContext()
+
     return (
         <FormControl error={invalid}>
             {label && <FormLabel required={required} error={invalid}>{label}</FormLabel>}
             <RadioGroup onChange={onRadioChange}
+                        ref={register(name).ref}
                         name={name}
                         row={row}
                         value={value || ''}>

--- a/packages/rhf-mui/src/SelectElement.tsx
+++ b/packages/rhf-mui/src/SelectElement.tsx
@@ -1,6 +1,6 @@
 import {createElement} from 'react'
 import {MenuItem, TextField, TextFieldProps} from '@mui/material'
-import {Control, Controller, ControllerProps, FieldError, Path} from 'react-hook-form'
+import {Control, Controller, ControllerProps, FieldError, Path, useFormContext} from 'react-hook-form'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 
 export type SelectElementProps<T extends FieldValues> = Omit<TextFieldProps, 'name' | 'type' | 'onChange'> & {
@@ -36,6 +36,8 @@ export default function SelectElement<TFieldValues extends FieldValues>({
         validation.required = 'This field is required'
     }
 
+    const { register } = useFormContext()
+
     return (
         <Controller
             name={name}
@@ -68,6 +70,7 @@ export default function SelectElement<TFieldValues extends FieldValues>({
                             rest.onChange(item)
                         }
                     }}
+                    ref={register(name).ref}
                     select
                     required={required}
                     error={invalid}

--- a/packages/rhf-mui/src/SliderElement.tsx
+++ b/packages/rhf-mui/src/SliderElement.tsx
@@ -1,4 +1,4 @@
-import {Control, Controller, Path} from 'react-hook-form'
+import {Control, Controller, Path, useFormContext} from 'react-hook-form'
 import {FormLabel, Slider, SliderProps} from '@mui/material'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 
@@ -14,6 +14,7 @@ export default function SliderElement<TFieldValues extends FieldValues>({
                                                                             label,
                                                                             ...other
                                                                         }: SliderElementProps<TFieldValues>) {
+    const { register } = useFormContext()
     return (
         <>
             {label && <FormLabel component="legend">{label}</FormLabel>}
@@ -25,6 +26,7 @@ export default function SliderElement<TFieldValues extends FieldValues>({
                         {...other}
                         value={value}
                         onChange={onChange}
+                        ref={register(name).ref}
                         valueLabelDisplay={other.valueLabelDisplay || 'auto'}
                     />
                 )}

--- a/packages/rhf-mui/src/SwitchElement.tsx
+++ b/packages/rhf-mui/src/SwitchElement.tsx
@@ -1,4 +1,4 @@
-import {Control, Controller, Path} from 'react-hook-form'
+import {Control, Controller, Path, useFormContext} from 'react-hook-form'
 import {FormControlLabel, FormControlLabelProps, Switch} from '@mui/material'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 
@@ -14,13 +14,14 @@ export default function SwitchElement<TFieldValues extends FieldValues>({
                                                                             control,
                                                                             ...other
                                                                         }: SwitchElementProps<TFieldValues>) {
+    const { register } = useFormContext()
     return (
         <FormControlLabel
             control={
                 <Controller
                     name={name}
                     control={control}
-                    render={({field}) => <Switch {...field} checked={!!field.value}/>}
+                    render={({field}) => <Switch {...field} ref={register(name).ref} checked={!!field.value}/>}
                 />
             }
             {...other}

--- a/packages/rhf-mui/src/TextFieldElement.tsx
+++ b/packages/rhf-mui/src/TextFieldElement.tsx
@@ -1,5 +1,5 @@
 import {TextField, TextFieldProps} from '@mui/material'
-import {Control, Controller, ControllerProps, FieldError, Path} from 'react-hook-form'
+import {Control, Controller, ControllerProps, FieldError, Path, useFormContext} from 'react-hook-form'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 
 export type TextFieldElementProps<T extends FieldValues = FieldValues> = Omit<TextFieldProps,
@@ -32,6 +32,8 @@ export default function TextFieldElement<TFieldValues extends FieldValues = Fiel
         }
     }
 
+    const { register } = useFormContext()
+
     return (
         <Controller
             name={name}
@@ -49,6 +51,7 @@ export default function TextFieldElement<TFieldValues extends FieldValues = Fiel
                         }
                     }}
                     onBlur={onBlur}
+                    ref={register(name).ref}
                     required={required}
                     type={type}
                     error={invalid}

--- a/packages/rhf-mui/src/TimePickerElement.tsx
+++ b/packages/rhf-mui/src/TimePickerElement.tsx
@@ -5,6 +5,7 @@ import {
   ControllerProps,
   FieldError,
   Path,
+  useFormContext,
 } from 'react-hook-form'
 import { TextField, TextFieldProps } from '@mui/material'
 import { FieldValues } from 'react-hook-form/dist/types/fields'
@@ -51,6 +52,8 @@ export default function TimePickerElement<TFieldValues extends FieldValues>({
     validation.required = 'This field is required'
   }
 
+  const { register } = useFormContext()
+
   return (
     <Controller
       name={name}
@@ -86,6 +89,7 @@ export default function TimePickerElement<TFieldValues extends FieldValues>({
           renderInput={(params) => (
             <TextField
               {...params}
+              ref={register(name).ref}
               inputProps={{
                 ...params?.inputProps,
                 ...(!value && {

--- a/packages/rhf-mui/src/ToggleButtonGroupElement.tsx
+++ b/packages/rhf-mui/src/ToggleButtonGroupElement.tsx
@@ -1,4 +1,4 @@
-import {Control, Controller, ControllerProps, FieldError, Path} from "react-hook-form";
+import {Control, Controller, ControllerProps, FieldError, Path, useFormContext} from "react-hook-form";
 import {FieldValues} from "react-hook-form/dist/types/fields";
 import {
     FormControl,
@@ -48,6 +48,7 @@ export default function ToggleButtonGroupElement<TFieldValues extends FieldValue
     }
 
     const isRequired = required || !!validation?.required;
+    const { register } = useFormContext()
     return (
         <Controller
             name={name}
@@ -70,6 +71,7 @@ export default function ToggleButtonGroupElement<TFieldValues extends FieldValue
                                     toggleButtonGroupProps.onChange(event, val)
                                 }
                             }}
+                            ref={register(name).ref}
                         >
                             {options.map(({label, id, ...toggleProps}) => (
                                 <ToggleButton value={id} {...toggleProps} key={id}>{label}</ToggleButton>


### PR DESCRIPTION
I noticed that the error focusing (built into react-hook-form) was not working correctly with material-ui. For some reason the ref from the Controller does not associate the underlying element properly with react-hook-form validation system, therefore I had to use the ref from register() instead. 

Now with the fix, submitting will focus on the first input that shows an error just like uncontrolled inputs. Until this is fixed upstream I think this is a suitable work-around.