### PR TITLE
Added renderIcon render prop to PasswordElement

### DIFF
--- a/packages/rhf-mui/src/PasswordElement.tsx
+++ b/packages/rhf-mui/src/PasswordElement.tsx
@@ -1,4 +1,4 @@
-import {MouseEvent, useState} from 'react'
+import {MouseEvent, ReactNode, useState} from 'react'
 import TextFieldElement, {TextFieldElementProps} from './TextFieldElement'
 import {IconButton, IconButtonProps, InputAdornment} from '@mui/material'
 import Visibility from '@mui/icons-material/Visibility'
@@ -8,10 +8,12 @@ import {FieldValues} from 'react-hook-form/dist/types/fields'
 export type PasswordElementProps<T extends FieldValues> =
   TextFieldElementProps<T> & {
     iconColor?: IconButtonProps['color']
+    renderIcon?: (password: boolean) => ReactNode
   }
 
 export default function PasswordElement<TFieldValues extends FieldValues>({
   iconColor,
+  renderIcon = (password) => (password ? <Visibility /> : <VisibilityOff />),
   ...props
 }: PasswordElementProps<TFieldValues>): JSX.Element {
   const [password, setPassword] = useState<boolean>(true)
@@ -29,7 +31,7 @@ export default function PasswordElement<TFieldValues extends FieldValues>({
               tabIndex={-1}
               color={iconColor ?? 'default'}
             >
-              {password ? <Visibility /> : <VisibilityOff />}
+              {renderIcon(password)}
             </IconButton>
           </InputAdornment>
         ),


### PR DESCRIPTION
Added option to customize `PasswordElement` InputAdornment icon.
Closes #122 