### PR TITLE
Always apply label props to RadioButtonGroup label

### DIFF
--- a/packages/rhf-mui/src/RadioButtonGroup.tsx
+++ b/packages/rhf-mui/src/RadioButtonGroup.tsx
@@ -120,6 +120,7 @@ export default function RadioButtonGroup<TFieldValues extends FieldValues>({
           const isChecked = val === optionKey
           return (
             <FormControlLabel
+              {...labelProps}
               control={
                 <Radio
                   sx={{


### PR DESCRIPTION
Label props were previously only being applied to options with an empty label. But they shoule be applied to all labels to allow customization with MUI props.