### PR TITLE
EmptyOptionLabel type Fix

### DIFF
--- a/packages/rhf-mui/src/RadioButtonGroup.tsx
+++ b/packages/rhf-mui/src/RadioButtonGroup.tsx
@@ -23,7 +23,7 @@ export type RadioButtonGroupProps<T extends FieldValues> = {
   labelKey?: string
   valueKey?: string
   type?: 'number' | 'string'
-  emptyOptionLabel?: 'string'
+  emptyOptionLabel?: string
   onChange?: (value: any) => void
   returnObject?: boolean
   row?: boolean


### PR DESCRIPTION
EmptyOptionLabel had a type of 'string' instead of string. 

Current code works fine but typescript will complain if you have anything other than string set as emptyOption.