### PR TITLE
Allow preservation of selected value order for MultiSelectElement

### DIFF
--- a/packages/rhf-mui/src/MultiSelectElement.tsx
+++ b/packages/rhf-mui/src/MultiSelectElement.tsx
@@ -33,6 +33,7 @@ export type MultiSelectElementProps<T extends FieldValues> = Omit<
   menuMaxWidth?: number
   helperText?: string
   showChips?: boolean
+  preserveOrder?: boolean
   control?: Control<T>
   showCheckbox?: boolean
   formControlProps?: Omit<FormControlProps, 'fullWidth' | 'variant'>
@@ -56,6 +57,7 @@ export default function MultiSelectElement<TFieldValues extends FieldValues>({
   minWidth = 120,
   helperText,
   showChips,
+  preserveOrder,
   control,
   showCheckbox,
   formControlProps,
@@ -131,7 +133,14 @@ export default function MultiSelectElement<TFieldValues extends FieldValues>({
                   : showChips
                   ? (selected) => (
                       <div style={{display: 'flex', flexWrap: 'wrap'}}>
-                        {((selected as any[]) || []).map((selectedValue) => (
+                        {(preserveOrder
+                          ? options
+                              .filter((option) =>
+                                (selected as any[]).includes(option[itemValue])
+                              )
+                              .map((option) => option[itemValue])
+                          : (selected as any[]) || []
+                        ).map((selectedValue) => (
                           <Chip
                             key={selectedValue}
                             label={selectedValue}

--- a/packages/rhf-mui/src/MultiSelectElement.tsx
+++ b/packages/rhf-mui/src/MultiSelectElement.tsx
@@ -134,11 +134,19 @@ export default function MultiSelectElement<TFieldValues extends FieldValues>({
                   ? (selected) => (
                       <div style={{display: 'flex', flexWrap: 'wrap'}}>
                         {(preserveOrder
-                          ? options
-                              .filter((option) =>
-                                (selected as any[]).includes(option[itemValue])
-                              )
-                              .map((option) => option[itemValue])
+                          ? itemValue !== null && itemValue !== ''
+                            ? options
+                                .filter((option) =>
+                                  (selected as any[]).includes(
+                                    option[itemValue]
+                                  )
+                                )
+                                .map((option) => option[itemValue])
+                            : options
+                                .filter((option) =>
+                                  (selected as any[]).includes(option.id)
+                                )
+                                .map((option) => option.id)
                           : (selected as any[]) || []
                         ).map((selectedValue) => (
                           <Chip


### PR DESCRIPTION
This pull request adds the attribute `preserveOrder` to `MultiSelectElement`. The attribute allows the preservation of the order of displayed selected values according to the sequence they were declared in within `options`, not according to the sequence they were selected in.

In the following example, the selected values were, in order of selection: `divorced`, `single`, `widowed`, `married`.

```typescript
import { Container, Stack } from "@mui/material";
import { FormContainer, MultiSelectElement } from "react-hook-form-mui";

const options = [
  {
    id: "single",
    label: "Single",
  },
  {
    id: "married",
    label: "Married",
  },
  {
    id: "divorced",
    label: "Divorced",
  },
  {
    id: "widowed",
    label: "Widowed",
  },
];

export default function Form() {
  return (
    <Container maxWidth="sm">
      <FormContainer>
        <Stack mt={2} spacing={2}>
          <MultiSelectElement
            itemValue="label"
            label="Ordered"
            name="maritalStatus"
            options={options}
            preserveOrder // <--- the new attribute
            showCheckbox
            showChips
          />
          <MultiSelectElement
            itemValue="label"
            label="Not Ordered"
            name="maritalStatus"
            options={options}
            showCheckbox
            showChips
          />
        </Stack>
      </FormContainer>
    </Container>
  );
}
```
![example](https://user-images.githubusercontent.com/11059331/229376961-83adf114-6ca9-4f3f-b5ba-4a1418c0a624.png)

If you would suggest a better naming for the attribute, then by all means.

Thank you very much!