### PR TITLE
checkbox sxProp handling fix

### DIFF
--- a/packages/rhf-mui/src/CheckboxElement.tsx
+++ b/packages/rhf-mui/src/CheckboxElement.tsx
@@ -68,10 +68,12 @@ export default function CheckboxElement<TFieldValues extends FieldValues>({
                   <Checkbox
                     {...rest}
                     color={rest.color || 'primary'}
-                    sx={{
-                      ...rest.sx,
-                      color: error ? 'error.main' : undefined,
-                    }}
+                    sx={[
+                      ...(Array.isArray(rest.sx) ? rest.sx : [rest.sx]),
+                      {
+                        color: error ? 'error.main' : undefined,
+                      },
+                    ]}
                     value={value}
                     checked={!!value}
                     onChange={(ev) => {


### PR DESCRIPTION
This pull request updates the logic to pass sxProp in checkbox to use the recommended by [material](https://mui.com/system/getting-started/the-sx-prop/#passing-the-sx-prop)

This preserves the usage of callbacks, arrays or objects in the sxProp correctly.

More info: https://github.com/dohomi/react-hook-form-mui/issues/151