### PR TITLE
Allow TextFieldElement use a different root component instead of TextField

### DIFF
--- a/packages/rhf-mui/src/TextFieldElement.tsx
+++ b/packages/rhf-mui/src/TextFieldElement.tsx
@@ -17,6 +17,12 @@ export type TextFieldElementProps<T extends FieldValues = FieldValues> = Omit<
   name: Path<T>
   parseError?: (error: FieldError) => string
   control?: Control<T>
+  /**
+   * You override the MUI's TextField component by passing a reference of the component you want to use.
+   *
+   * This is especially useful when you want to use a customized version of TextField.
+   */
+  component?: typeof TextField
 }
 
 export default function TextFieldElement<
@@ -28,6 +34,7 @@ export default function TextFieldElement<
   required,
   name,
   control,
+  component: TextFieldComponent = TextField,
   ...rest
 }: TextFieldElementProps<TFieldValues>): JSX.Element {
   const errorMsgFn = useFormError()
@@ -54,7 +61,7 @@ export default function TextFieldElement<
         field: {value, onChange, onBlur, ref},
         fieldState: {error},
       }) => (
-        <TextField
+        <TextFieldComponent
           {...rest}
           name={name}
           value={value ?? ''}


### PR DESCRIPTION
This is a common feature on MUI components where you can decide what React element to use for the root component. 

The main purpose of this change is to allow using custom versions of MUI's TextField with TextFieldElement. 

MUI has several ways to customize its components. One of those ways is creating non-global styled versions (using the `styled()` HOC). 

For TextField, choosing that option is more common since this component doesn't allow you to create new "variants". 

With the changes proposed in the PR, developers could pass an "styled" version of their TextFields to the optional `component` prop of `TextFieldElement`.