### PR TITLE
Custom value transforms

### DIFF
--- a/apps/storybook/stories/Checkbox.stories.tsx
+++ b/apps/storybook/stories/Checkbox.stories.tsx
@@ -30,3 +30,11 @@ LabelPosition.args = {
     labelPlacement: 'top',
   },
 }
+
+export const CustomTransform = Template.bind({})
+CustomTransform.args = {
+  label: 'Label',
+  name: 'basic',
+  transformValue: (checked: boolean) => (checked ? 'checked' : 'unchecked'),
+  parseValue: (value) => value === 'checked',
+}

--- a/apps/storybook/stories/Switch.stories.tsx
+++ b/apps/storybook/stories/Switch.stories.tsx
@@ -35,3 +35,11 @@ Disabled.args = {
   label: 'Disabled Switch',
   disabled: true,
 }
+
+export const CustomTransform = Template.bind({})
+CustomTransform.args = {
+  label: 'Label',
+  name: 'switch',
+  transformValue: (checked: boolean) => (checked ? 'checked' : 'unchecked'),
+  parseValue: (value) => value === 'checked',
+}

--- a/apps/storybook/stories/TextFieldElement.stories.tsx
+++ b/apps/storybook/stories/TextFieldElement.stories.tsx
@@ -275,3 +275,53 @@ export const WithFormErrorProvider = () => (
     </FormContainer>
   </FormErrorProvider>
 )
+
+export const WithTransformations = () => {
+  const form = {
+    lowercase: 'play with me',
+    numbersOnly: 12345,
+  }
+  return (
+    <FormContainer
+      defaultValues={form}
+      onSuccess={action('submit')}
+      FormProps={{
+        'aria-autocomplete': 'none',
+      }}
+    >
+      <p>
+        You can use <code>transformValue</code> and <code>parseValue</code> to
+        present the stored value in a different format to the user.
+      </p>
+      <TextFieldElement
+        name={'lowercase'}
+        margin={'dense'}
+        label={'Lowercase transformation'}
+        parseValue={(value) => String(value).toUpperCase()}
+        transformValue={(value) => String(value).toLowerCase()}
+        helperText={
+          'The text is always shown in uppercase, but stored in lowercase'
+        }
+        required
+      />
+      <br />
+      <TextFieldElement
+        name={'numbersOnly'}
+        margin={'dense'}
+        label={'Numbers only'}
+        transformValue={(value) => {
+          const valueAsNUmber = parseFloat(value as string)
+          if (isNaN(valueAsNUmber)) {
+            return 0
+          }
+          return valueAsNUmber
+        }}
+        helperText={
+          'Transforms the input value into a number without using type="number"'
+        }
+        required
+      />
+      <SubmitButton />
+    </FormContainer>
+  )
+}

--- a/packages/rhf-mui/src/CheckboxElement.tsx
+++ b/packages/rhf-mui/src/CheckboxElement.tsx
@@ -28,7 +28,21 @@ export type CheckboxElementProps<T extends FieldValues> = Omit<
   helperText?: string
   control?: Control<T>
   labelProps?: Omit<FormControlLabelProps, 'label' | 'control'>
+  /**
+   * Function to transform the value from the form controller to a boolean that can be used by the MUI Checkbox component.
+   *
+   * You probably want to use this prop together with `transformValue`.
+   */
+  parseValue?: (formDataValue: unknown) => boolean
+  /**
+   * Function to transform the input value before sending it to the Form Controller.
+   *
+   * You probably want to use this prop together with `parseValue`.
+   */
+  transformValue?: (checked: boolean) => unknown
 }
+
+const defaultTransform = (value: any): any => value
 
 export default function CheckboxElement<TFieldValues extends FieldValues>({
   name,
@@ -39,6 +53,8 @@ export default function CheckboxElement<TFieldValues extends FieldValues>({
   control,
   helperText,
   labelProps,
+  parseValue = defaultTransform,
+  transformValue = defaultTransform,
   ...rest
 }: CheckboxElementProps<TFieldValues>): JSX.Element {
   const errorMsgFn = useFormError()
@@ -73,11 +89,11 @@ export default function CheckboxElement<TFieldValues extends FieldValues>({
                       color: error ? 'error.main' : undefined,
                     }}
                     value={value}
-                    checked={!!value}
+                    checked={!!parseValue(value)}
                     onChange={(ev) => {
-                      onChange(!value)
+                      onChange(transformValue(ev.target.checked))
                       if (typeof rest.onChange === 'function') {
-                        rest.onChange(ev, !value)
+                        rest.onChange(ev, !ev.target.checked)
                       }
                     }}
                   />

--- a/packages/rhf-mui/src/SwitchElement.tsx
+++ b/packages/rhf-mui/src/SwitchElement.tsx
@@ -7,20 +7,44 @@ type IProps = Omit<FormControlLabelProps, 'control'>
 export type SwitchElementProps<T extends FieldValues> = IProps & {
   name: Path<T>
   control?: Control<T>
+  /**
+   * Function to transform the value from the form controller to a boolean that can be used by the MUI Switch component.
+   *
+   * You probably want to use this prop together with `transformValue`.
+   */
+  parseValue?: (formDataValue: unknown) => boolean
+  /**
+   * Function to transform the input value before sending it to the Form Controller.
+   *
+   * You probably want to use this prop together with `parseValue`.
+   */
+  transformValue?: (checked: boolean) => unknown
 }
+
+const defaultTransform = (value: any): any => value
 
 export default function SwitchElement<TFieldValues extends FieldValues>({
   name,
   control,
+  parseValue = defaultTransform,
+  transformValue = defaultTransform,
   ...other
 }: SwitchElementProps<TFieldValues>) {
   return (
     <Controller
       name={name}
       control={control}
-      render={({field}) => (
+      render={({field: {onChange, ...field}}) => (
         <FormControlLabel
-          control={<Switch {...field} checked={!!field.value} />}
+          control={
+            <Switch
+              {...field}
+              checked={!!parseValue(field.value)}
+              onChange={(ev) => {
+                onChange(transformValue(ev.target.checked))
+              }}
+            />
+          }
           {...other}
         />
       )}

--- a/packages/rhf-mui/src/TextFieldElement.tsx
+++ b/packages/rhf-mui/src/TextFieldElement.tsx
@@ -17,7 +17,21 @@ export type TextFieldElementProps<T extends FieldValues = FieldValues> = Omit<
   name: Path<T>
   parseError?: (error: FieldError) => string
   control?: Control<T>
+  /**
+   * Function to transform the value from the form controller to a boolean that can be used by the MUI TextField component.
+   *
+   * You probably want to use this prop together with `transformValue`.
+   */
+  parseValue?: (formDataValue: unknown) => string
+  /**
+   * Function to transform the input value before sending it to the Form Controller.
+   *
+   * You probably want to use this prop together with `parseValue`.
+   */
+  transformValue?: (inputValue: string | number) => unknown
 }
+
+const defaultTransform = (value: any): any => value
 
 export default function TextFieldElement<
   TFieldValues extends FieldValues = FieldValues
@@ -28,6 +42,8 @@ export default function TextFieldElement<
   required,
   name,
   control,
+  parseValue = defaultTransform,
+  transformValue = defaultTransform,
   ...rest
 }: TextFieldElementProps<TFieldValues>): JSX.Element {
   const errorMsgFn = useFormError()
@@ -57,12 +73,14 @@ export default function TextFieldElement<
         <TextField
           {...rest}
           name={name}
-          value={value ?? ''}
+          value={parseValue(value) ?? ''}
           onChange={(ev) => {
             onChange(
-              type === 'number' && ev.target.value
-                ? +ev.target.value
-                : ev.target.value
+              transformValue(
+                type === 'number' && ev.target.value
+                  ? +ev.target.value
+                  : ev.target.value
+              )
             )
             if (typeof rest.onChange === 'function') {
               rest.onChange(ev)


### PR DESCRIPTION
I'm working on a project where a huge JSON with a key-value structure where all the data are strings.
A form is created dynamically based on this JSON structure and based on pre-defined rules, some of these properties are presented as text fields, text fields that allow numbers only, and others as checkboxes.

The form data then needs to be sent back to the backend in the same format as it was received, with all its values as strings.

react-hook-form documentation includes [an example](https://www.react-hook-form.com/advanced-usage/#TransformandParse) to transform the values back and forward between the form data and the UI component but the current implementation of CheckBoxElement and TextFieldElement does not allow making these changes.

That's why I'm creating this PR.

> I closed my previous PR with the same title because I forgot to change the email address of my commits 😅.