### PR TITLE
Updated parseError type declaration to allow wieder range of return types

### DIFF
--- a/packages/rhf-mui/src/AutocompleteElement.tsx
+++ b/packages/rhf-mui/src/AutocompleteElement.tsx
@@ -15,6 +15,7 @@ import {
 import CircularProgress from '@mui/material/CircularProgress'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
+import {ReactNode} from 'react'
 
 export type AutocompleteElementProps<
   F extends FieldValues,
@@ -29,7 +30,7 @@ export type AutocompleteElementProps<
   multiple?: M
   matchId?: boolean
   rules?: ControllerProps['rules']
-  parseError?: (error: FieldError) => string
+  parseError?: (error: FieldError) => ReactNode
   required?: boolean
   label?: TextFieldProps['label']
   showCheckbox?: boolean

--- a/packages/rhf-mui/src/CheckboxButtonGroup.tsx
+++ b/packages/rhf-mui/src/CheckboxButtonGroup.tsx
@@ -18,13 +18,14 @@ import {
 } from 'react-hook-form'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
+import {ReactNode} from 'react'
 
 export type CheckboxButtonGroupProps<T extends FieldValues> = {
   options: {id: string | number; label: string}[] | any[]
   helperText?: string
   name: Path<T>
   required?: boolean
-  parseError?: (error: FieldError) => string
+  parseError?: (error: FieldError) => ReactNode
   label?: string
   labelKey?: string
   valueKey?: string

--- a/packages/rhf-mui/src/CheckboxElement.tsx
+++ b/packages/rhf-mui/src/CheckboxElement.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/material'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
+import {ReactNode} from 'react'
 
 export type CheckboxElementProps<T extends FieldValues> = Omit<
   CheckboxProps,
@@ -23,7 +24,7 @@ export type CheckboxElementProps<T extends FieldValues> = Omit<
 > & {
   validation?: ControllerProps['rules']
   name: Path<T>
-  parseError?: (error: FieldError) => string
+  parseError?: (error: FieldError) => ReactNode
   label?: FormControlLabelProps['label']
   helperText?: string
   control?: Control<T>

--- a/packages/rhf-mui/src/DatePickerElement.tsx
+++ b/packages/rhf-mui/src/DatePickerElement.tsx
@@ -13,6 +13,7 @@ import {
 import {TextFieldProps} from '@mui/material'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
+import {ReactNode} from 'react'
 
 export type DatePickerElementProps<
   T extends FieldValues,
@@ -22,7 +23,7 @@ export type DatePickerElementProps<
   name: Path<T>
   required?: boolean
   isDate?: boolean
-  parseError?: (error: FieldError) => string
+  parseError?: (error: FieldError) => ReactNode
   validation?: ControllerProps['rules']
   control?: Control<T>
   inputProps?: TextFieldProps

--- a/packages/rhf-mui/src/DateTimePickerElement.tsx
+++ b/packages/rhf-mui/src/DateTimePickerElement.tsx
@@ -13,6 +13,7 @@ import {
 import {TextFieldProps} from '@mui/material'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
+import {ReactNode} from 'react'
 
 export type DateTimePickerElementProps<
   T extends FieldValues,
@@ -22,7 +23,7 @@ export type DateTimePickerElementProps<
   name: Path<T>
   required?: boolean
   isDate?: boolean
-  parseError?: (error: FieldError) => string
+  parseError?: (error: FieldError) => ReactNode
   validation?: ControllerProps['rules']
   control?: Control<T>
   inputProps?: TextFieldProps

--- a/packages/rhf-mui/src/MobileDatePickerElement.tsx
+++ b/packages/rhf-mui/src/MobileDatePickerElement.tsx
@@ -13,6 +13,7 @@ import {
 import {TextFieldProps} from '@mui/material'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
+import {ReactNode} from 'react'
 
 export type MobileDatePickerElementProps<
   T extends FieldValues,
@@ -22,7 +23,7 @@ export type MobileDatePickerElementProps<
   name: Path<T>
   required?: boolean
   isDate?: boolean
-  parseError?: (error: FieldError) => string
+  parseError?: (error: FieldError) => ReactNode
   validation?: ControllerProps['rules']
   control?: Control<T>
   inputProps?: TextFieldProps

--- a/packages/rhf-mui/src/MultiSelectElement.tsx
+++ b/packages/rhf-mui/src/MultiSelectElement.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mui/material'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
+import {ReactNode} from 'react'
 
 export type MultiSelectElementProps<T extends FieldValues> = Omit<
   SelectProps,
@@ -27,7 +28,7 @@ export type MultiSelectElementProps<T extends FieldValues> = Omit<
   required?: boolean
   validation?: any
   name: Path<T>
-  parseError?: (error: FieldError) => string
+  parseError?: (error: FieldError) => ReactNode
   minWidth?: number
   menuMaxHeight?: number
   menuMaxWidth?: number

--- a/packages/rhf-mui/src/RadioButtonGroup.tsx
+++ b/packages/rhf-mui/src/RadioButtonGroup.tsx
@@ -1,4 +1,4 @@
-import {ChangeEvent} from 'react'
+import {ChangeEvent, ReactNode} from 'react'
 import {Control, FieldError, Path, useController} from 'react-hook-form'
 import {
   FormControl,
@@ -19,7 +19,7 @@ export type RadioButtonGroupProps<T extends FieldValues> = {
   helperText?: string
   name: Path<T>
   required?: boolean
-  parseError?: (error: FieldError) => string
+  parseError?: (error: FieldError) => ReactNode
   label?: string
   labelKey?: string
   valueKey?: string

--- a/packages/rhf-mui/src/SelectElement.tsx
+++ b/packages/rhf-mui/src/SelectElement.tsx
@@ -1,4 +1,4 @@
-import {createElement} from 'react'
+import {ReactNode, createElement} from 'react'
 import {MenuItem, TextField, TextFieldProps} from '@mui/material'
 import {
   Control,
@@ -22,7 +22,7 @@ export type SelectElementProps<T extends FieldValues> = Omit<
   valueKey?: string
   labelKey?: string
   type?: 'string' | 'number'
-  parseError?: (error: FieldError) => string
+  parseError?: (error: FieldError) => ReactNode
   objectOnChange?: boolean
   onChange?: (value: any) => void
   control?: Control<T>

--- a/packages/rhf-mui/src/SliderElement.tsx
+++ b/packages/rhf-mui/src/SliderElement.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
+import {ReactNode} from 'react'
 
 export type SliderElementProps<T extends FieldValues> = Omit<
   SliderProps,
@@ -24,7 +25,7 @@ export type SliderElementProps<T extends FieldValues> = Omit<
   control?: Control<T>
   label?: string
   rules?: ControllerProps['rules']
-  parseError?: (error: FieldError) => string
+  parseError?: (error: FieldError) => ReactNode
   required?: boolean
   formControlProps?: FormControlProps
 }

--- a/packages/rhf-mui/src/TextFieldElement.tsx
+++ b/packages/rhf-mui/src/TextFieldElement.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-hook-form'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
+import {ReactNode} from 'react'
 
 export type TextFieldElementProps<T extends FieldValues = FieldValues> = Omit<
   TextFieldProps,
@@ -15,7 +16,7 @@ export type TextFieldElementProps<T extends FieldValues = FieldValues> = Omit<
 > & {
   validation?: ControllerProps['rules']
   name: Path<T>
-  parseError?: (error: FieldError) => string
+  parseError?: (error: FieldError) => ReactNode
   control?: Control<T>
   /**
    * You override the MUI's TextField component by passing a reference of the component you want to use.

--- a/packages/rhf-mui/src/TextareaAutosizeElement.tsx
+++ b/packages/rhf-mui/src/TextareaAutosizeElement.tsx
@@ -7,14 +7,14 @@ import {
   Path,
 } from 'react-hook-form'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
-import {CSSProperties} from 'react'
+import {CSSProperties, ReactNode} from 'react'
 import {useFormError} from './FormErrorProvider'
 
 export type TextareaAutosizeElementProps<T extends FieldValues = FieldValues> =
   Omit<TextFieldProps, 'name' | 'type'> & {
     validation?: ControllerProps['rules']
     name: Path<T>
-    parseError?: (error: FieldError) => string
+    parseError?: (error: FieldError) => ReactNode
     control?: Control<T>
     resizeStyle?: CSSProperties['resize']
   }

--- a/packages/rhf-mui/src/TimePickerElement.tsx
+++ b/packages/rhf-mui/src/TimePickerElement.tsx
@@ -13,6 +13,7 @@ import {
 import {TextFieldProps} from '@mui/material'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
+import {ReactNode} from 'react'
 
 export type TimePickerElementProps<
   T extends FieldValues,
@@ -22,7 +23,7 @@ export type TimePickerElementProps<
   name: Path<T>
   required?: boolean
   isDate?: boolean
-  parseError?: (error: FieldError) => string
+  parseError?: (error: FieldError) => ReactNode
   validation?: ControllerProps['rules']
   control?: Control<T>
   inputProps?: TextFieldProps

--- a/packages/rhf-mui/src/ToggleButtonGroupElement.tsx
+++ b/packages/rhf-mui/src/ToggleButtonGroupElement.tsx
@@ -30,7 +30,7 @@ export type ToggleButtonGroupElementProps<T extends FieldValues> =
     label?: string
     validation?: ControllerProps['rules']
     name: Path<T>
-    parseError?: (error: FieldError) => string
+    parseError?: (error: FieldError) => ReactNode
     control?: Control<T>
     options: SingleToggleButtonProps[]
     formLabelProps?: FormLabelProps


### PR DESCRIPTION
# Problem
Currently, `parseError` does only allow `string` as `ReturnType`, which limits the option on transforming errors

# Solution
Updating the `parseError` type declaration to allow `ReactNode` the type of the `helperText` prop/Component.