### PR TITLE
#149 possible custom loader indicator

### DIFF
--- a/apps/storybook/stories/AutocompleteElement.stories.tsx
+++ b/apps/storybook/stories/AutocompleteElement.stories.tsx
@@ -4,7 +4,7 @@ import {Meta, StoryObj} from '@storybook/react'
 import {action} from '@storybook/addon-actions'
 import {Box, Button, Tooltip} from '@mui/material'
 import LocationIcon from '@mui/icons-material/LocationOn'
-
+import AutoModeIcon from '@mui/icons-material/AutoMode'
 const meta = {
   title: 'Autocomplete',
   component: AutocompleteElement,
@@ -113,6 +113,18 @@ export const Loading = {
     multiple: true,
     showCheckbox: true,
     loading: true,
+  },
+}
+
+export const WithCustomLoading = {
+  args: {
+    label: 'Loading State',
+    name: 'loading',
+    options: [],
+    multiple: true,
+    showCheckbox: true,
+    loading: true,
+    loadingIndicator: <AutoModeIcon />,
   },
 }
 

--- a/packages/rhf-mui/src/AutocompleteElement.tsx
+++ b/packages/rhf-mui/src/AutocompleteElement.tsx
@@ -29,6 +29,7 @@ export type AutocompleteElementProps<
   loading?: boolean
   multiple?: M
   matchId?: boolean
+  loadingIndicator?: ReactNode
   rules?: ControllerProps<F>['rules']
   parseError?: (error: FieldError) => ReactNode
   required?: boolean
@@ -55,6 +56,7 @@ export default function AutocompleteElement<TFieldValues extends FieldValues>({
   loading,
   showCheckbox,
   rules,
+  loadingIndicator,
   required,
   multiple,
   matchId,
@@ -74,6 +76,11 @@ export default function AutocompleteElement<TFieldValues extends FieldValues>({
       required: rules?.required || 'This field is required',
     }),
   }
+
+  const loadingElement = loadingIndicator || (
+    <CircularProgress color="inherit" size={20} />
+  )
+
   return (
     <Controller
       name={name}
@@ -161,9 +168,7 @@ export default function AutocompleteElement<TFieldValues extends FieldValues>({
                   ...params.InputProps,
                   endAdornment: (
                     <>
-                      {loading ? (
-                        <CircularProgress color="inherit" size={20} />
-                      ) : null}
+                      {loading ? loadingElement : null}
                       {params.InputProps.endAdornment}
                     </>
                   ),


### PR DESCRIPTION
I've implemented a simple solution to the custom loading spinner problem for the Autocomplete Component.
Also added a storybook example using a MUI Icon as the loading indicator.

Would it make sense to include that as a feature?