### PR TITLE
DateTimePicker: defaultValue is null

### DIFF
--- a/packages/rhf-mui/src/DateTimePickerElement.tsx
+++ b/packages/rhf-mui/src/DateTimePickerElement.tsx
@@ -56,7 +56,7 @@ export default function DateTimePickerElement<
       name={name}
       rules={validation}
       control={control}
-      defaultValue={'' as any}
+      defaultValue={null as any}
       render={({field, fieldState: {error}}) => {
         if (field?.value && typeof field?.value === 'string') {
           field.value = new Date(field.value) as any // need to see if this works for all localization adaptors


### PR DESCRIPTION
Fixes #197. For some reason, the `defaultValue` prop is set to `''` (empty string), on the `Controller` component inside `DateTimePickerElement`. By contrast, the corresponding `defaultValue` prop on the `DatePickerElement` and `TimePickerElement` components are both set to `null`.  `DatePickerElement` and `TimePickerElement` both work with the latest version of `@mui/x-date-pickers`, but `DateTimePickerElement` does not.

Changing this `defaultValue` to `null` resolves the inconsistency, and I _believe_ should also make the component work with the latest version of `@mui/x-date-pickers` (although I have not actually tested that claim).