### PR TITLE
Fix persistent error text in MultiSelectElement

### DIFF
--- a/packages/rhf-mui/src/MultiSelectElement.tsx
+++ b/packages/rhf-mui/src/MultiSelectElement.tsx
@@ -82,7 +82,7 @@ export default function MultiSelectElement<TFieldValues extends FieldValues>({
       rules={validation}
       control={control}
       render={({field: {value, onChange, onBlur}, fieldState: {error}}) => {
-        helperText = error
+        const parsedHelperText = error
           ? typeof customErrorFn === 'function'
             ? customErrorFn(error)
             : error.message
@@ -192,7 +192,7 @@ export default function MultiSelectElement<TFieldValues extends FieldValues>({
                 )
               })}
             </Select>
-            {helperText && <FormHelperText>{helperText}</FormHelperText>}
+            {parsedHelperText && <FormHelperText error={!!error}>{parsedHelperText}</FormHelperText>}
           </FormControl>
         )
       }}


### PR DESCRIPTION
The error message in the helper text of a MultiSelectElement would persist (without error styling) after the error was no longer applicable.

The top element in each image is the original, the bottom is the fixed version.
Invalid:
<img width="276" alt="invalid" src="https://github.com/dohomi/react-hook-form-mui/assets/103616575/6694b6b1-52ad-4169-a5c4-b1d388dc6dc8">
Valid:
<img width="276" alt="valid" src="https://github.com/dohomi/react-hook-form-mui/assets/103616575/39bacb8f-bbc2-4693-bdff-46cbf3f96232">


