### PR TITLE
Allow ref and inputRef for components

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "packageManager": "yarn@1.22.19",
   "lint-staged": {
     "*.{js,ts,tsx}": [
-      "prettier --write"
+      "prettier --write",
+      "eslint --fix"
     ]
   },
   "simple-git-hooks": {

--- a/packages/rhf-mui/src/CheckboxButtonGroup.tsx
+++ b/packages/rhf-mui/src/CheckboxButtonGroup.tsx
@@ -11,19 +11,22 @@ import {
 } from '@mui/material'
 import {
   Control,
-  ControllerProps,
   FieldError,
-  Path,
+  FieldPath,
+  UseControllerProps,
   useController,
+  FieldValues,
 } from 'react-hook-form'
-import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
-import {ReactNode} from 'react'
+import {ReactNode, forwardRef, Ref, RefAttributes} from 'react'
 
-export type CheckboxButtonGroupProps<T extends FieldValues> = {
+export type CheckboxButtonGroupProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = {
   options: {id: string | number; label: string}[] | any[]
   helperText?: ReactNode
-  name: Path<T>
+  name: TName
   required?: boolean
   parseError?: (error: FieldError) => ReactNode
   label?: string
@@ -33,33 +36,50 @@ export type CheckboxButtonGroupProps<T extends FieldValues> = {
   returnObject?: boolean
   disabled?: boolean
   row?: boolean
-  control?: Control<T>
-  rules?: ControllerProps<T>['rules']
+  control?: Control<TFieldValues>
+  rules?: UseControllerProps<TFieldValues, TName>['rules']
   checkboxColor?: CheckboxProps['color']
   labelProps?: Omit<FormControlLabelProps, 'label' | 'control'>
 }
 
-export default function CheckboxButtonGroup<TFieldValues extends FieldValues>({
-  helperText,
-  options,
-  label,
-  name,
-  parseError,
-  required,
-  labelKey = 'label',
-  valueKey = 'id',
-  returnObject,
-  disabled,
-  row,
-  control,
-  checkboxColor,
-  rules,
-  labelProps,
-  ...rest
-}: CheckboxButtonGroupProps<TFieldValues>): JSX.Element {
+type CheckboxButtonGroupComponent = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: CheckboxButtonGroupProps<TFieldValues, TName> &
+    RefAttributes<HTMLDivElement>
+) => JSX.Element
+
+const CheckboxButtonGroup = forwardRef(function CheckboxButtonGroup<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: CheckboxButtonGroupProps<TFieldValues, TName>,
+  ref: Ref<HTMLDivElement>
+): JSX.Element {
+  const {
+    helperText,
+    options,
+    label,
+    name,
+    parseError,
+    required,
+    labelKey = 'label',
+    valueKey = 'id',
+    returnObject,
+    disabled,
+    row,
+    control,
+    checkboxColor,
+    rules,
+    labelProps,
+    ...rest
+  } = props
+
+  const theme = useTheme()
   const errorMsgFn = useFormError()
   const customErrorFn = parseError || errorMsgFn
-  const theme = useTheme()
+
   const {
     field: {value = [], onChange},
     fieldState: {error},
@@ -69,7 +89,7 @@ export default function CheckboxButtonGroup<TFieldValues extends FieldValues>({
     control,
   })
 
-  helperText = error
+  const renderHelperText = error
     ? typeof customErrorFn === 'function'
       ? customErrorFn(error)
       : error.message
@@ -101,7 +121,7 @@ export default function CheckboxButtonGroup<TFieldValues extends FieldValues>({
   }
 
   return (
-    <FormControl error={!!error} required={required}>
+    <FormControl error={!!error} required={required} ref={ref}>
       {label && <FormLabel error={!!error}>{label}</FormLabel>}
       <FormGroup row={row}>
         {options.map((option: any) => {
@@ -137,7 +157,9 @@ export default function CheckboxButtonGroup<TFieldValues extends FieldValues>({
           )
         })}
       </FormGroup>
-      {helperText && <FormHelperText>{helperText}</FormHelperText>}
+      {renderHelperText && <FormHelperText>{renderHelperText}</FormHelperText>}
     </FormControl>
   )
-}
+}) as CheckboxButtonGroupComponent
+
+export default CheckboxButtonGroup

--- a/packages/rhf-mui/src/DatePickerElement.tsx
+++ b/packages/rhf-mui/src/DatePickerElement.tsx
@@ -10,9 +10,9 @@ import {
   FieldPath,
   UseControllerProps,
   PathValue,
+  FieldValues,
 } from 'react-hook-form'
 import {TextFieldProps, useForkRef} from '@mui/material'
-import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
 import {ReactNode, forwardRef, Ref, RefAttributes} from 'react'
 import {DateValidationError} from '@mui/x-date-pickers'

--- a/packages/rhf-mui/src/DatePickerElement.tsx
+++ b/packages/rhf-mui/src/DatePickerElement.tsx
@@ -5,15 +5,16 @@ import {
 } from '@mui/x-date-pickers/DatePicker'
 import {
   Control,
-  Controller,
-  ControllerProps,
   FieldError,
-  Path,
+  useController,
+  FieldPath,
+  UseControllerProps,
+  PathValue,
 } from 'react-hook-form'
-import {TextFieldProps} from '@mui/material'
+import {TextFieldProps, useForkRef} from '@mui/material'
 import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
-import {ReactNode} from 'react'
+import {ReactNode, forwardRef, Ref, RefAttributes} from 'react'
 import {DateValidationError} from '@mui/x-date-pickers'
 import {defaultErrorMessages} from './messages/DatePicker'
 import {
@@ -22,16 +23,16 @@ import {
 } from '@mui/x-date-pickers/internals'
 
 export type DatePickerElementProps<
-  T extends FieldValues,
-  TInputDate,
-  TDate = TInputDate
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TDate = PathValue<TFieldValues, TName>
 > = Omit<DatePickerProps<TDate>, 'value' | 'slotProps'> & {
-  name: Path<T>
+  name: TName
   required?: boolean
   isDate?: boolean
   parseError?: (error: FieldError | DateValidationError) => ReactNode
-  validation?: ControllerProps<T>['rules']
-  control?: Control<T>
+  validation?: UseControllerProps<TFieldValues, TName>['rules']
+  control?: Control<TFieldValues>
   inputProps?: TextFieldProps
   helperText?: TextFieldProps['helperText']
   textReadOnly?: boolean
@@ -39,115 +40,141 @@ export type DatePickerElementProps<
   overwriteErrorMessages?: typeof defaultErrorMessages
 }
 
-export default function DatePickerElement<TFieldValues extends FieldValues>({
-  parseError,
-  name,
-  required,
-  validation = {},
-  inputProps,
-  control,
-  textReadOnly,
-  slotProps,
-  overwriteErrorMessages,
-  ...rest
-}: DatePickerElementProps<TFieldValues, any, any>): JSX.Element {
+type DatePickerElementComponent = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: DatePickerElementProps<TFieldValues, TName> &
+    RefAttributes<HTMLDivElement>
+) => JSX.Element
+
+const DatePickerElement = forwardRef(function DatePickerElement<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: DatePickerElementProps<TFieldValues, TName>,
+  ref: Ref<HTMLDivElement>
+): JSX.Element {
+  const {
+    parseError,
+    name,
+    required,
+    validation = {},
+    inputProps,
+    control,
+    textReadOnly,
+    slotProps,
+    overwriteErrorMessages,
+    inputRef,
+    ...rest
+  } = props
+
+  const adapter = useLocalizationContext()
+
+  const errorMsgFn = useFormError()
+  const customErrorFn = parseError || errorMsgFn
+
   const errorMessages = {
     ...defaultErrorMessages,
     ...overwriteErrorMessages,
   }
-  const errorMsgFn = useFormError()
-  const adapter = useLocalizationContext()
 
-  const customErrorFn = parseError || errorMsgFn
-  if (required && !validation.required) {
-    validation.required = 'This field is required'
-  }
+  const rules = {
+    ...validation,
+    ...(required &&
+      !validation.required && {
+      required: 'This field is required',
+    }),
+    validate: {
+      internal: (value) => {
+        const inputTimezone =
+          value == null || !adapter.utils.isValid(value)
+            ? null
+            : adapter.utils.getTimezone(value)
 
-  validation.validate = {
-    internal: (value) => {
-      const inputTimezone =
-        value == null || !adapter.utils.isValid(value)
-          ? null
-          : adapter.utils.getTimezone(value)
-
-      const internalError = validateDate({
-        props: {
-          shouldDisableDate: rest.shouldDisableDate,
-          shouldDisableMonth: rest.shouldDisableMonth,
-          shouldDisableYear: rest.shouldDisableYear,
-          disablePast: Boolean(rest.disablePast),
-          disableFuture: Boolean(rest.disableFuture),
-          minDate: rest.minDate,
-          maxDate: rest.maxDate,
-          timezone: rest.timezone ?? inputTimezone ?? 'default',
-        },
-        value,
-        adapter,
-      })
-      return internalError == null || errorMessages[internalError]
+        const internalError = validateDate({
+          props: {
+            shouldDisableDate: rest.shouldDisableDate,
+            shouldDisableMonth: rest.shouldDisableMonth,
+            shouldDisableYear: rest.shouldDisableYear,
+            disablePast: Boolean(rest.disablePast),
+            disableFuture: Boolean(rest.disableFuture),
+            minDate: rest.minDate,
+            maxDate: rest.maxDate,
+            timezone: rest.timezone ?? inputTimezone ?? 'default',
+          },
+          value,
+          adapter,
+        })
+        return internalError == null || errorMessages[internalError]
+      },
+      ...validation.validate,
     },
-    ...validation.validate,
   }
+
+  const {
+    field,
+    fieldState: {error},
+  } = useController({
+    name,
+    control,
+    rules,
+    defaultValue: null as any,
+  })
+
+  const handleInputRef = useForkRef(field.ref, inputRef)
+
+  if (field?.value && typeof field?.value === 'string') {
+    field.value = new Date(field.value) as any // need to see if this works for all localization adaptors
+  }
+
+  const errorMessage = error
+    ? typeof customErrorFn === 'function'
+      ? customErrorFn(error)
+      : error.message
+    : null
 
   return (
-    <Controller
-      name={name}
-      rules={validation}
-      control={control}
-      defaultValue={null as any}
-      render={({field, fieldState: {error}}) => {
-        if (field?.value && typeof field?.value === 'string') {
-          field.value = new Date(field.value) as any // need to see if this works for all localization adaptors
+    <DatePicker
+      {...rest}
+      {...field}
+      ref={ref}
+      inputRef={handleInputRef}
+      onClose={(...args) => {
+        field.onBlur()
+        if (rest.onClose) {
+          rest.onClose(...args)
         }
-
-        const errorMessage = error
-          ? typeof customErrorFn === 'function'
-            ? customErrorFn(error)
-            : error.message
-          : null
-        return (
-          <DatePicker
-            {...rest}
-            {...field}
-            ref={(r) => {
-              field.ref(r?.querySelector('input'))
-            }}
-            onClose={(...args) => {
-              field.onBlur()
-              if (rest.onClose) {
-                rest.onClose(...args)
-              }
-            }}
-            onChange={(v, keyboardInputValue) => {
-              field.onChange(v, keyboardInputValue)
-              if (typeof rest.onChange === 'function') {
-                rest.onChange(v, keyboardInputValue)
-              }
-            }}
-            slotProps={{
-              ...slotProps,
-              textField: {
-                ...inputProps,
-                required,
-                onBlur: (event) => {
-                  field.onBlur()
-                  if (typeof inputProps?.onBlur === 'function') {
-                    inputProps.onBlur(event)
-                  }
-                },
-                error: !!errorMessage,
-                helperText: errorMessage
-                  ? errorMessage
-                  : inputProps?.helperText || rest.helperText,
-                inputProps: {
-                  readOnly: !!textReadOnly,
-                  ...inputProps?.inputProps,
-                },
-              },
-            }}
-          />
-        )
+      }}
+      onChange={(v, keyboardInputValue) => {
+        field.onChange(v, keyboardInputValue)
+        if (typeof rest.onChange === 'function') {
+          rest.onChange(v, keyboardInputValue)
+        }
+      }}
+      slotProps={{
+        ...slotProps,
+        textField: {
+          ...inputProps,
+          required,
+          onBlur: (event) => {
+            field.onBlur()
+            if (typeof inputProps?.onBlur === 'function') {
+              inputProps.onBlur(event)
+            }
+          },
+          error: !!errorMessage,
+          helperText: errorMessage
+            ? errorMessage
+            : inputProps?.helperText || rest.helperText,
+          inputProps: {
+            readOnly: !!textReadOnly,
+            ...inputProps?.inputProps,
+          },
+        },
       }}
     />
   )
-}
+}) as DatePickerElementComponent
+
+export default DatePickerElement

--- a/packages/rhf-mui/src/MobileDatePickerElement.tsx
+++ b/packages/rhf-mui/src/MobileDatePickerElement.tsx
@@ -5,97 +5,159 @@ import {
 } from '@mui/x-date-pickers/MobileDatePicker'
 import {
   Control,
-  Controller,
-  ControllerProps,
   FieldError,
-  Path,
+  FieldValues,
+  FieldPath,
+  PathValue,
+  UseControllerProps,
+  useController,
 } from 'react-hook-form'
-import {TextFieldProps} from '@mui/material'
-import {FieldValues} from 'react-hook-form/dist/types/fields'
+import {TextFieldProps, useForkRef} from '@mui/material'
 import {useFormError} from './FormErrorProvider'
-import {ReactNode} from 'react'
+import {ReactNode, forwardRef, RefAttributes, Ref} from 'react'
+import {defaultErrorMessages} from './messages/DatePicker'
+import {
+  useLocalizationContext,
+  validateDate,
+} from '@mui/x-date-pickers/internals'
 
 export type MobileDatePickerElementProps<
-  T extends FieldValues,
-  TInputDate,
-  TDate = TInputDate
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TDate = PathValue<TFieldValues, TName>
 > = Omit<MobileDatePickerProps<TDate>, 'value' | 'slotProps'> & {
-  name: Path<T>
+  name: TName
   required?: boolean
   isDate?: boolean
   parseError?: (error: FieldError) => ReactNode
-  validation?: ControllerProps<T>['rules']
-  control?: Control<T>
+  validation?: UseControllerProps<TFieldValues, TName>['rules']
+  control?: Control<TFieldValues>
   inputProps?: TextFieldProps
   helperText?: TextFieldProps['helperText']
   slotProps?: Omit<MobileDatePickerSlotsComponentsProps<TDate>, 'textField'>
+  overwriteErrorMessages?: typeof defaultErrorMessages
 }
 
-export default function MobileDatePickerElement<
-  TFieldValues extends FieldValues
->({
-  parseError,
-  name,
-  required,
-  validation = {},
-  inputProps,
-  control,
-  slotProps,
-  ...rest
-}: MobileDatePickerElementProps<TFieldValues, any, any>): JSX.Element {
+type MobileDatePickerElementComponent = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: MobileDatePickerElementProps<TFieldValues, TName> &
+    RefAttributes<HTMLDivElement>
+) => JSX.Element
+
+const MobileDatePickerElement = forwardRef(function MobileDatePickerElement<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: MobileDatePickerElementProps<TFieldValues, TName>,
+  ref: Ref<HTMLDivElement>
+): JSX.Element {
+  const {
+    parseError,
+    name,
+    required,
+    validation = {},
+    inputProps,
+    control,
+    slotProps,
+    overwriteErrorMessages,
+    inputRef,
+    ...rest
+  } = props
+
+  const adapter = useLocalizationContext()
+
   const errorMsgFn = useFormError()
   const customErrorFn = parseError || errorMsgFn
-  if (required && !validation.required) {
-    validation.required = 'This field is required'
+
+  const errorMessages = {
+    ...defaultErrorMessages,
+    ...overwriteErrorMessages,
+  }
+
+  const rules = {
+    ...validation,
+    ...(required &&
+      !validation.required && {
+      required: 'This field is required',
+    }),
+    validate: {
+      internal: (value) => {
+        const inputTimezone =
+          value == null || !adapter.utils.isValid(value)
+            ? null
+            : adapter.utils.getTimezone(value)
+
+        const internalError = validateDate({
+          props: {
+            shouldDisableDate: rest.shouldDisableDate,
+            shouldDisableMonth: rest.shouldDisableMonth,
+            shouldDisableYear: rest.shouldDisableYear,
+            disablePast: Boolean(rest.disablePast),
+            disableFuture: Boolean(rest.disableFuture),
+            minDate: rest.minDate,
+            maxDate: rest.maxDate,
+            timezone: rest.timezone ?? inputTimezone ?? 'default',
+          },
+          value,
+          adapter,
+        })
+        return internalError == null || errorMessages[internalError]
+      },
+      ...validation.validate,
+    },
+  }
+
+  const {
+    field,
+    fieldState: {error},
+  } = useController({
+    name,
+    control,
+    rules,
+    defaultValue: null as any,
+  })
+
+  const handleInputRef = useForkRef(field.value, inputRef)
+
+  if (field?.value && typeof field?.value === 'string') {
+    field.value = new Date(field.value) as any // need to see if this works for all localization adaptors
   }
 
   return (
-    <Controller
-      name={name}
-      rules={validation}
-      control={control}
-      defaultValue={null as any}
-      render={({field, fieldState: {error}}) => {
-        if (field?.value && typeof field?.value === 'string') {
-          field.value = new Date(field.value) as any // need to see if this works for all localization adaptors
+    <MobileDatePicker
+      {...rest}
+      {...field}
+      ref={ref}
+      inputRef={handleInputRef}
+      onClose={(...args) => {
+        field.onBlur()
+        if (rest.onClose) {
+          rest.onClose(...args)
         }
-
-        return (
-          <MobileDatePicker
-            {...rest}
-            {...field}
-            ref={(r) => {
-              field.ref(r?.querySelector('input'))
-            }}
-            onClose={(...args) => {
-              field.onBlur()
-              if (rest.onClose) {
-                rest.onClose(...args)
-              }
-            }}
-            onChange={(v, keyboardInputValue) => {
-              // console.log(v, keyboardInputValue)
-              field.onChange(v, keyboardInputValue)
-              if (typeof rest.onChange === 'function') {
-                rest.onChange(v, keyboardInputValue)
-              }
-            }}
-            slotProps={{
-              ...slotProps,
-              textField: {
-                ...inputProps,
-                required,
-                error: !!error,
-                helperText: error
-                  ? typeof customErrorFn === 'function'
-                    ? customErrorFn(error)
-                    : error.message
-                  : inputProps?.helperText || rest.helperText,
-              },
-            }}
-          />
-        )
+      }}
+      onChange={(v, keyboardInputValue) => {
+        field.onChange(v, keyboardInputValue)
+        if (typeof rest.onChange === 'function') {
+          rest.onChange(v, keyboardInputValue)
+        }
+      }}
+      slotProps={{
+        ...slotProps,
+        textField: {
+          ...inputProps,
+          required,
+          error: !!error,
+          helperText: error
+            ? typeof customErrorFn === 'function'
+              ? customErrorFn(error)
+              : error.message
+            : inputProps?.helperText || rest.helperText,
+        },
       }}
     />
   )
-}
+}) as MobileDatePickerElementComponent
+
+export default MobileDatePickerElement

--- a/packages/rhf-mui/src/MultiSelectElement.tsx
+++ b/packages/rhf-mui/src/MultiSelectElement.tsx
@@ -1,5 +1,12 @@
 import CloseIcon from '@mui/icons-material/Cancel'
-import {Control, Controller, FieldError, Path} from 'react-hook-form'
+import {
+  Control,
+  FieldError,
+  FieldValues,
+  FieldPath,
+  UseControllerProps,
+  useController,
+} from 'react-hook-form'
 import {
   Checkbox,
   Chip,
@@ -11,23 +18,23 @@ import {
   MenuItem,
   Select,
   SelectProps,
+  useForkRef,
 } from '@mui/material'
-import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
-import {ReactNode} from 'react'
+import {ReactNode, forwardRef, RefAttributes, Ref} from 'react'
 
-export type MultiSelectElementProps<T extends FieldValues> = Omit<
-  SelectProps,
-  'value'
-> & {
+export type MultiSelectElementProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = Omit<SelectProps, 'value'> & {
   options: {id: string | number; label: string}[] | any[]
   label?: string
   itemKey?: string
   itemValue?: string
   itemLabel?: string
   required?: boolean
-  validation?: any
-  name: Path<T>
+  validation?: UseControllerProps<TFieldValues, TName>['rules']
+  name: TName
   parseError?: (error: FieldError) => ReactNode
   minWidth?: number
   menuMaxHeight?: number
@@ -35,175 +42,197 @@ export type MultiSelectElementProps<T extends FieldValues> = Omit<
   helperText?: ReactNode
   showChips?: boolean
   preserveOrder?: boolean
-  control?: Control<T>
+  control?: Control<TFieldValues>
   showCheckbox?: boolean
   formControlProps?: Omit<FormControlProps, 'fullWidth' | 'variant'>
 }
 
+type MultiSelectElementComponent = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: MultiSelectElementProps<TFieldValues, TName> &
+    RefAttributes<HTMLDivElement>
+) => JSX.Element
+
 const ITEM_HEIGHT = 48
 const ITEM_PADDING_TOP = 8
 
-export default function MultiSelectElement<TFieldValues extends FieldValues>({
-  options,
-  label = '',
-  itemKey = 'id',
-  itemValue = '',
-  itemLabel = 'label',
-  required = false,
-  validation = {},
-  parseError,
-  name,
-  menuMaxHeight = ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
-  menuMaxWidth = 250,
-  minWidth = 120,
-  helperText,
-  showChips,
-  preserveOrder,
-  control,
-  showCheckbox,
-  formControlProps,
-  ...rest
-}: MultiSelectElementProps<TFieldValues>): JSX.Element {
+const MultiSelectElement = forwardRef(function MultiSelectElement<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: MultiSelectElementProps<TFieldValues, TName>,
+  ref: Ref<HTMLDivElement>
+): JSX.Element {
+  const {
+    options,
+    label = '',
+    itemKey = 'id',
+    itemValue = '',
+    itemLabel = 'label',
+    required = false,
+    validation = {},
+    parseError,
+    name,
+    menuMaxHeight = ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+    menuMaxWidth = 250,
+    minWidth = 120,
+    helperText,
+    showChips,
+    preserveOrder,
+    control,
+    showCheckbox,
+    formControlProps,
+    inputRef,
+    ...rest
+  } = props
+
   const errorMsgFn = useFormError()
   const customErrorFn = parseError || errorMsgFn
+
   const renderLabel = (item: any) =>
     options.find((op) => {
       const optionVal = op[itemValue || itemKey] ?? op
       return optionVal === item
     })?.[itemLabel] ?? item
 
-  if (required && !validation.required) {
-    validation.required = 'This field is required'
+  const rules = {
+    ...validation,
+    ...(required &&
+      !validation.required && {
+      required: 'This field is required',
+    }),
   }
 
+  const {
+    field,
+    fieldState: {error},
+  } = useController({
+    name,
+    rules,
+    control,
+  })
+
+  const handleInputRef = useForkRef(field.ref, inputRef)
+
+  const renderHelperText = error
+    ? typeof customErrorFn === 'function'
+      ? customErrorFn(error)
+      : error.message
+    : helperText
+
   return (
-    <Controller
-      name={name}
-      rules={validation}
-      control={control}
-      render={({
-        field: {value, onChange, onBlur, ref},
-        fieldState: {error},
-      }) => {
-        const parsedHelperText = error
-          ? typeof customErrorFn === 'function'
-            ? customErrorFn(error)
-            : error.message
-          : helperText
-        return (
-          <FormControl
-            {...formControlProps}
-            style={{
-              ...formControlProps?.style,
-              minWidth,
-            }}
-            variant={rest.variant}
-            fullWidth={rest.fullWidth}
-            error={!!error}
-            size={rest.size}
-          >
-            {label && (
-              <InputLabel
-                size={rest.size === 'small' ? 'small' : undefined}
-                error={!!error}
-                htmlFor={rest.id || `select-multi-select-${name}`}
-                required={required}
-              >
-                {label}
-              </InputLabel>
-            )}
-            <Select
-              {...rest}
-              id={rest.id || `select-multi-select-${name}`}
-              multiple
-              label={label || undefined}
-              error={!!error}
-              value={value || []}
-              required={required}
-              onChange={onChange}
-              onBlur={onBlur}
-              MenuProps={{
-                ...rest.MenuProps,
-                PaperProps: {
-                  ...(rest.MenuProps?.PaperProps ?? {
-                    style: {
-                      maxHeight: menuMaxHeight,
-                      width: menuMaxWidth,
-                      ...rest.MenuProps?.PaperProps?.style,
-                    },
-                  }),
-                },
-              }}
-              renderValue={
-                typeof rest.renderValue === 'function'
-                  ? rest.renderValue
-                  : showChips
-                  ? (selected) => (
-                      <div style={{display: 'flex', flexWrap: 'wrap'}}>
-                        {(preserveOrder
-                          ? options.filter((option) =>
-                              (selected as any[]).includes(option)
-                            )
-                          : (selected as any[]) || []
-                        ).map((selectedValue) => (
-                          <Chip
-                            key={selectedValue}
-                            label={renderLabel(selectedValue)}
-                            style={{display: 'flex', flexWrap: 'wrap'}}
-                            onDelete={() => {
-                              onChange(
-                                value.filter((i: any) => i !== selectedValue)
-                              )
-                              // setValue(name, formValue.filter((i: any) => i !== value), { shouldValidate: true })
-                            }}
-                            deleteIcon={
-                              <CloseIcon
-                                onMouseDown={(ev) => {
-                                  ev.stopPropagation()
-                                }}
-                              />
-                            }
-                          />
-                        ))}
-                      </div>
-                    )
-                  : (selected) =>
-                      Array.isArray(selected)
-                        ? selected.map(renderLabel).join(', ')
-                        : ''
-              }
-              inputRef={ref}
-            >
-              {options.map((item) => {
-                const val: string | number = item[itemValue || itemKey] || item
-                const isChecked = Array.isArray(value)
-                  ? value.includes(val)
-                  : false
-                return (
-                  <MenuItem
-                    key={val}
-                    value={val}
-                    sx={{
-                      fontWeight: (theme) =>
-                        isChecked
-                          ? theme.typography.fontWeightBold
-                          : theme.typography.fontWeightRegular,
-                    }}
-                  >
-                    {showCheckbox && <Checkbox checked={isChecked} />}
-                    <ListItemText primary={item[itemLabel] || item} />
-                  </MenuItem>
-                )
-              })}
-            </Select>
-            {parsedHelperText && (
-              <FormHelperText error={!!error}>
-                {parsedHelperText}
-              </FormHelperText>
-            )}
-          </FormControl>
-        )
+    <FormControl
+      {...formControlProps}
+      style={{
+        ...formControlProps?.style,
+        minWidth,
       }}
-    />
+      variant={rest.variant}
+      fullWidth={rest.fullWidth}
+      error={!!error}
+      size={rest.size}
+      ref={ref}
+    >
+      {label && (
+        <InputLabel
+          size={rest.size === 'small' ? 'small' : undefined}
+          error={!!error}
+          htmlFor={rest.id || `select-multi-select-${name}`}
+          required={required}
+        >
+          {label}
+        </InputLabel>
+      )}
+      <Select
+        {...rest}
+        id={rest.id || `select-multi-select-${name}`}
+        multiple
+        label={label || undefined}
+        error={!!error}
+        value={field.value || []}
+        required={required}
+        onChange={field.onChange}
+        onBlur={field.onBlur}
+        MenuProps={{
+          ...rest.MenuProps,
+          PaperProps: {
+            ...(rest.MenuProps?.PaperProps ?? {
+              style: {
+                maxHeight: menuMaxHeight,
+                width: menuMaxWidth,
+                ...rest.MenuProps?.PaperProps?.style,
+              },
+            }),
+          },
+        }}
+        renderValue={
+          typeof rest.renderValue === 'function'
+            ? rest.renderValue
+            : showChips
+              ? (selected) => (
+                <div style={{display: 'flex', flexWrap: 'wrap'}}>
+                  {(preserveOrder
+                    ? options.filter((option) =>
+                      (selected as any[]).includes(option)
+                    )
+                    : (selected as any[]) || []
+                  ).map((selectedValue) => (
+                    <Chip
+                      key={selectedValue}
+                      label={renderLabel(selectedValue)}
+                      style={{display: 'flex', flexWrap: 'wrap'}}
+                      onDelete={() => {
+                        field.onChange(
+                          field.value.filter((i: any) => i !== selectedValue)
+                        )
+                      }}
+                      deleteIcon={
+                        <CloseIcon
+                          onMouseDown={(ev) => {
+                            ev.stopPropagation()
+                          }}
+                        />
+                      }
+                    />
+                  ))}
+                </div>
+              )
+              : (selected) =>
+                Array.isArray(selected)
+                  ? selected.map(renderLabel).join(', ')
+                  : ''
+        }
+        inputRef={handleInputRef}
+      >
+        {options.map((item) => {
+          const val: string | number = item[itemValue || itemKey] || item
+          const isChecked = Array.isArray(field.value)
+            ? field.value.includes(val)
+            : false
+          return (
+            <MenuItem
+              key={val}
+              value={val}
+              sx={{
+                fontWeight: (theme) =>
+                  isChecked
+                    ? theme.typography.fontWeightBold
+                    : theme.typography.fontWeightRegular,
+              }}
+            >
+              {showCheckbox && <Checkbox checked={isChecked} />}
+              <ListItemText primary={item[itemLabel] || item} />
+            </MenuItem>
+          )
+        })}
+      </Select>
+      {renderHelperText && (
+        <FormHelperText error={!!error}>{renderHelperText}</FormHelperText>
+      )}
+    </FormControl>
   )
-}
+}) as MultiSelectElementComponent
+
+export default MultiSelectElement

--- a/packages/rhf-mui/src/PasswordElement.tsx
+++ b/packages/rhf-mui/src/PasswordElement.tsx
@@ -1,25 +1,50 @@
-import {MouseEvent, ReactNode, useState} from 'react'
+import {
+  MouseEvent,
+  ReactNode,
+  useState,
+  RefAttributes,
+  forwardRef,
+  Ref,
+} from 'react'
 import TextFieldElement, {TextFieldElementProps} from './TextFieldElement'
 import {IconButton, IconButtonProps, InputAdornment} from '@mui/material'
 import Visibility from '@mui/icons-material/Visibility'
 import VisibilityOff from '@mui/icons-material/VisibilityOff'
-import {FieldValues} from 'react-hook-form/dist/types/fields'
+import {FieldPath, FieldValues} from 'react-hook-form'
 
-export type PasswordElementProps<T extends FieldValues> =
-  TextFieldElementProps<T> & {
-    iconColor?: IconButtonProps['color']
-    renderIcon?: (password: boolean) => ReactNode
-  }
+export type PasswordElementProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = TextFieldElementProps<TFieldValues, TName> & {
+  iconColor?: IconButtonProps['color']
+  renderIcon?: (password: boolean) => ReactNode
+}
 
-export default function PasswordElement<TFieldValues extends FieldValues>({
-  iconColor,
-  renderIcon = (password) => (password ? <Visibility /> : <VisibilityOff />),
-  ...props
-}: PasswordElementProps<TFieldValues>): JSX.Element {
+type PasswordElementComponent = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: PasswordElementProps<TFieldValues, TName> &
+    RefAttributes<HTMLDivElement>
+) => JSX.Element
+
+const PasswordElement = forwardRef(function PasswordElement<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: PasswordElementProps<TFieldValues, TName>,
+  ref: Ref<HTMLDivElement>
+): JSX.Element {
+  const {
+    iconColor,
+    renderIcon = (password) => (password ? <Visibility /> : <VisibilityOff />),
+    ...rest
+  } = props
   const [password, setPassword] = useState<boolean>(true)
   return (
     <TextFieldElement
-      {...props}
+      {...rest}
+      ref={ref}
       InputProps={{
         endAdornment: (
           <InputAdornment position={'end'}>
@@ -39,4 +64,6 @@ export default function PasswordElement<TFieldValues extends FieldValues>({
       type={password ? 'password' : 'text'}
     />
   )
-}
+}) as PasswordElementComponent
+
+export default PasswordElement

--- a/packages/rhf-mui/src/PasswordRepeatElement.tsx
+++ b/packages/rhf-mui/src/PasswordRepeatElement.tsx
@@ -35,7 +35,7 @@ const PasswordRepeatElement = forwardRef(function PasswordRepeatElement<
     TPasswordName
   >,
   ref: Ref<HTMLDivElement>
-) {
+): JSX.Element {
   const {passwordFieldName, customInvalidFieldMessage, control, ...rest} = props
 
   const pwValue = useWatch({

--- a/packages/rhf-mui/src/PasswordRepeatElement.tsx
+++ b/packages/rhf-mui/src/PasswordRepeatElement.tsx
@@ -1,28 +1,53 @@
 import PasswordElement, {PasswordElementProps} from './PasswordElement'
-import {Path, useWatch} from 'react-hook-form'
-import {FieldValues} from 'react-hook-form/dist/types/fields'
+import {FieldPath, useWatch, FieldValues} from 'react-hook-form'
+import {forwardRef, Ref, RefAttributes} from 'react'
 
-export type PasswordRepeatElementProps<T extends FieldValues> =
-  PasswordElementProps<T> & {
-    passwordFieldName: Path<T>
-    customInvalidFieldMessage?: string
-  }
-export default function PasswordRepeatElement<
-  TFieldValues extends FieldValues
->({
-  passwordFieldName,
-  customInvalidFieldMessage,
-  ...rest
-}: PasswordRepeatElementProps<TFieldValues>) {
+export type PasswordRepeatElementProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TConfirmPasswordName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TPasswordName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = PasswordElementProps<TFieldValues, TConfirmPasswordName> & {
+  passwordFieldName: TPasswordName
+  customInvalidFieldMessage?: string
+}
+
+type PasswordRepeatElementComponent = <
+  TFieldValues extends FieldValues = FieldValues,
+  TConfirmPasswordName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TPasswordName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: PasswordRepeatElementProps<
+    TFieldValues,
+    TConfirmPasswordName,
+    TPasswordName
+  > &
+    RefAttributes<HTMLDivElement>
+) => JSX.Element
+
+const PasswordRepeatElement = forwardRef(function PasswordRepeatElement<
+  TFieldValues extends FieldValues = FieldValues,
+  TConfirmPasswordName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TPasswordName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: PasswordRepeatElementProps<
+    TFieldValues,
+    TConfirmPasswordName,
+    TPasswordName
+  >,
+  ref: Ref<HTMLDivElement>
+) {
+  const {passwordFieldName, customInvalidFieldMessage, control, ...rest} = props
+
   const pwValue = useWatch({
     name: passwordFieldName,
-    control: rest.control,
+    control,
   })
   const invalidFieldMessage =
     customInvalidFieldMessage ?? 'Password should match'
   return (
     <PasswordElement
       {...rest}
+      ref={ref}
       validation={{
         validate: (value: string) => {
           return value === pwValue || invalidFieldMessage
@@ -30,4 +55,6 @@ export default function PasswordRepeatElement<
       }}
     />
   )
-}
+}) as PasswordRepeatElementComponent
+
+export default PasswordRepeatElement

--- a/packages/rhf-mui/src/SelectElement.tsx
+++ b/packages/rhf-mui/src/SelectElement.tsx
@@ -1,21 +1,21 @@
-import {ReactNode, createElement} from 'react'
-import {MenuItem, TextField, TextFieldProps} from '@mui/material'
+import {ReactNode, createElement, forwardRef, Ref, RefAttributes} from 'react'
+import {MenuItem, TextField, TextFieldProps, useForkRef} from '@mui/material'
 import {
   Control,
-  Controller,
-  ControllerProps,
   FieldError,
-  Path,
+  FieldValues,
+  FieldPath,
+  UseControllerProps,
+  useController,
 } from 'react-hook-form'
-import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
 
-export type SelectElementProps<T extends FieldValues> = Omit<
-  TextFieldProps,
-  'name' | 'type' | 'onChange'
-> & {
-  validation?: ControllerProps<T>['rules']
-  name: Path<T>
+export type SelectElementProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = Omit<TextFieldProps, 'name' | 'type' | 'onChange'> & {
+  validation?: UseControllerProps<TFieldValues, TName>['rules']
+  name: TName
   options?:
     | readonly {
         id: string | number
@@ -29,94 +29,116 @@ export type SelectElementProps<T extends FieldValues> = Omit<
   parseError?: (error: FieldError) => ReactNode
   objectOnChange?: boolean
   onChange?: (value: any) => void
-  control?: Control<T>
+  control?: Control<TFieldValues>
 }
 
-export default function SelectElement<TFieldValues extends FieldValues>({
-  name,
-  required,
-  valueKey = 'id',
-  labelKey = 'label',
-  options = [],
-  parseError,
-  type,
-  objectOnChange,
-  validation = {},
-  control,
-  ...rest
-}: SelectElementProps<TFieldValues>): JSX.Element {
+type SelectElementComponent = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: SelectElementProps<TFieldValues, TName> & RefAttributes<HTMLDivElement>
+) => JSX.Element
+
+const SelectElement = forwardRef(function SelectElement<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: SelectElementProps<TFieldValues, TName>,
+  ref: Ref<HTMLDivElement>
+): JSX.Element {
+  const {
+    name,
+    required,
+    valueKey = 'id',
+    labelKey = 'label',
+    options = [],
+    parseError,
+    type,
+    objectOnChange,
+    validation = {},
+    control,
+    inputRef,
+    ...rest
+  } = props
+
   const errorMsgFn = useFormError()
   const customErrorFn = parseError || errorMsgFn
   const isNativeSelect = !!rest.SelectProps?.native
   const ChildComponent = isNativeSelect ? 'option' : MenuItem
 
-  if (required && !validation.required) {
-    validation.required = 'This field is required'
+  const rules = {
+    ...validation,
+    ...(required &&
+      !validation.required && {
+      required: 'This field is required',
+    }),
   }
 
+  const {
+    field,
+    fieldState: {error},
+  } = useController({
+    name,
+    rules,
+    control,
+  })
+
+  const handleInputRef = useForkRef(field.ref, inputRef)
+
+  // handle shrink on number input fields
+  if (type === 'number' && typeof field.value !== 'undefined') {
+    rest.InputLabelProps = rest.InputLabelProps || {}
+    rest.InputLabelProps.shrink = true
+  }
+
+  const currentValue = field.value?.[valueKey] ?? field.value // try fetch key value
+
   return (
-    <Controller
+    <TextField
+      {...rest}
       name={name}
-      rules={validation}
-      control={control}
-      render={({
-        field: {onBlur, onChange, value, ref},
-        fieldState: {error},
-      }) => {
-        // handle shrink on number input fields
-        if (type === 'number' && typeof value !== 'undefined') {
-          rest.InputLabelProps = rest.InputLabelProps || {}
-          rest.InputLabelProps.shrink = true
+      value={currentValue ?? ''}
+      onBlur={field.onBlur}
+      ref={ref}
+      onChange={(event) => {
+        let item: number | string = event.target.value
+        if (type === 'number' && item) {
+          item = Number(item)
         }
-
-        value = value?.[valueKey] ?? value // try fetch key value
-
-        return (
-          <TextField
-            {...rest}
-            name={name}
-            value={value ?? ''}
-            onBlur={onBlur}
-            onChange={(event) => {
-              let item: number | string = event.target.value
-              if (type === 'number' && item) {
-                item = Number(item)
-              }
-              onChange(item)
-              if (typeof rest.onChange === 'function') {
-                if (objectOnChange) {
-                  item = options.find((i) => i[valueKey] === item)
-                }
-                rest.onChange(item)
-              }
-            }}
-            select
-            required={required}
-            error={!!error}
-            helperText={
-              error
-                ? typeof customErrorFn === 'function'
-                  ? customErrorFn(error)
-                  : error.message
-                : rest.helperText
-            }
-            inputRef={ref}
-          >
-            {isNativeSelect && <option />}
-            {options.map((item: any) =>
-              createElement(
-                ChildComponent,
-                {
-                  key: `${name}_${item[valueKey]}`,
-                  value: item?.[valueKey] ?? item,
-                  disabled: item?.disabled ?? false,
-                },
-                item[labelKey]
-              )
-            )}
-          </TextField>
-        )
+        field.onChange(item)
+        if (typeof rest.onChange === 'function') {
+          if (objectOnChange) {
+            item = options.find((i) => i[valueKey] === item)
+          }
+          rest.onChange(item)
+        }
       }}
-    />
+      select
+      required={required}
+      error={!!error}
+      helperText={
+        error
+          ? typeof customErrorFn === 'function'
+            ? customErrorFn(error)
+            : error.message
+          : rest.helperText
+      }
+      inputRef={handleInputRef}
+    >
+      {isNativeSelect && <option />}
+      {options.map((item: any) =>
+        createElement(
+          ChildComponent,
+          {
+            key: `${name}_${item[valueKey]}`,
+            value: item?.[valueKey] ?? item,
+            disabled: item?.disabled ?? false,
+          },
+          item[labelKey]
+        )
+      )}
+    </TextField>
   )
-}
+}) as SelectElementComponent
+
+export default SelectElement

--- a/packages/rhf-mui/src/SliderElement.tsx
+++ b/packages/rhf-mui/src/SliderElement.tsx
@@ -1,9 +1,10 @@
 import {
   Control,
-  Controller,
-  ControllerProps,
   FieldError,
-  Path,
+  FieldValues,
+  FieldPath,
+  UseControllerProps,
+  useController,
 } from 'react-hook-form'
 import {
   FormControl,
@@ -13,75 +14,94 @@ import {
   Slider,
   SliderProps,
 } from '@mui/material'
-import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
-import {ReactNode} from 'react'
+import {ReactNode, forwardRef, RefAttributes, Ref} from 'react'
 
-export type SliderElementProps<T extends FieldValues> = Omit<
-  SliderProps,
-  'control'
-> & {
-  name: Path<T>
-  control?: Control<T>
+export type SliderElementProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = Omit<SliderProps, 'control'> & {
+  name: TName
+  control?: Control<TFieldValues>
   label?: string
-  rules?: ControllerProps<T>['rules']
+  rules?: UseControllerProps<TFieldValues, TName>['rules']
   parseError?: (error: FieldError) => ReactNode
   required?: boolean
   formControlProps?: FormControlProps
 }
 
-export default function SliderElement<TFieldValues extends FieldValues>({
-  name,
-  control,
-  label,
-  rules = {},
-  parseError,
-  required,
-  formControlProps,
-  ...other
-}: SliderElementProps<TFieldValues>) {
+type SliderElementComponent = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: SliderElementProps<TFieldValues, TName> & RefAttributes<HTMLDivElement>
+) => JSX.Element
+
+const SliderElement = forwardRef(function SliderElement<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(props: SliderElementProps<TFieldValues, TName>, ref: Ref<HTMLDivElement>) {
+  const {
+    name,
+    control,
+    label,
+    rules = {},
+    parseError,
+    required,
+    formControlProps,
+    ...other
+  } = props
+
   const errorMsgFn = useFormError()
   const customErrorFn = parseError || errorMsgFn
-  if (required && !rules.required) {
-    rules.required = 'This field is required'
+
+  const validationRules = {
+    ...rules,
+    ...(required &&
+      !rules.required && {
+      required: 'This field is required',
+    }),
   }
+
+  const {
+    field,
+    fieldState: {error, invalid},
+  } = useController({
+    name,
+    control,
+    rules: validationRules,
+  })
+
+  const parsedHelperText = error
+    ? typeof customErrorFn === 'function'
+      ? customErrorFn(error)
+      : error.message
+    : null
+
   return (
-    <Controller
-      name={name}
-      control={control}
-      rules={rules}
-      render={({field: {onChange, value}, fieldState: {invalid, error}}) => {
-        const parsedHelperText = error
-          ? typeof customErrorFn === 'function'
-            ? customErrorFn(error)
-            : error.message
-          : null
-        return (
-          <FormControl
-            error={invalid}
-            required={required}
-            fullWidth
-            {...formControlProps}
-          >
-            {label && (
-              <FormLabel component="legend" error={invalid}>
-                {label}
-              </FormLabel>
-            )}
-            <Slider
-              {...other}
-              value={value}
-              onChange={onChange}
-              valueLabelDisplay={other.valueLabelDisplay || 'auto'}
-            />
-            {parsedHelperText && (
-              <FormHelperText error={invalid}>
-                {parsedHelperText}
-              </FormHelperText>
-            )}
-          </FormControl>
-        )
-      }}
-    />
+    <FormControl
+      error={invalid}
+      required={required}
+      fullWidth
+      {...formControlProps}
+      ref={ref}
+    >
+      {label && (
+        <FormLabel component="legend" error={invalid}>
+          {label}
+        </FormLabel>
+      )}
+      <Slider
+        {...other}
+        value={field.value}
+        onChange={field.onChange}
+        valueLabelDisplay={other.valueLabelDisplay || 'auto'}
+      />
+      {parsedHelperText && (
+        <FormHelperText error={invalid}>{parsedHelperText}</FormHelperText>
+      )}
+    </FormControl>
   )
-}
+}) as SliderElementComponent
+
+export default SliderElement

--- a/packages/rhf-mui/src/SliderElement.tsx
+++ b/packages/rhf-mui/src/SliderElement.tsx
@@ -40,7 +40,10 @@ type SliderElementComponent = <
 const SliderElement = forwardRef(function SliderElement<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
->(props: SliderElementProps<TFieldValues, TName>, ref: Ref<HTMLDivElement>) {
+>(
+  props: SliderElementProps<TFieldValues, TName>,
+  ref: Ref<HTMLDivElement>
+): JSX.Element {
   const {
     name,
     control,

--- a/packages/rhf-mui/src/TextFieldElement.tsx
+++ b/packages/rhf-mui/src/TextFieldElement.tsx
@@ -1,23 +1,23 @@
-import {TextField, TextFieldProps} from '@mui/material'
+import {TextField, useForkRef, TextFieldProps} from '@mui/material'
 import {
   Control,
-  Controller,
-  ControllerProps,
   FieldError,
-  Path,
+  FieldPath,
+  UseControllerProps,
+  FieldValues,
+  useController,
 } from 'react-hook-form'
-import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
-import {ReactNode} from 'react'
+import {forwardRef, ReactNode, RefAttributes, Ref} from 'react'
 
-export type TextFieldElementProps<T extends FieldValues = FieldValues> = Omit<
-  TextFieldProps,
-  'name'
-> & {
-  validation?: ControllerProps<T>['rules']
-  name: Path<T>
+export type TextFieldElementProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = Omit<TextFieldProps, 'name'> & {
+  validation: UseControllerProps<TFieldValues, TName>['rules']
+  name: TName
   parseError?: (error: FieldError) => ReactNode
-  control?: Control<T>
+  control?: Control<TFieldValues>
   /**
    * You override the MUI's TextField component by passing a reference of the component you want to use.
    *
@@ -26,70 +26,92 @@ export type TextFieldElementProps<T extends FieldValues = FieldValues> = Omit<
   component?: typeof TextField
 }
 
-export default function TextFieldElement<
-  TFieldValues extends FieldValues = FieldValues
->({
-  validation = {},
-  parseError,
-  type,
-  required,
-  name,
-  control,
-  component: TextFieldComponent = TextField,
-  ...rest
-}: TextFieldElementProps<TFieldValues>): JSX.Element {
+type TextFieldElementComponent = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: TextFieldElementProps<TFieldValues, TName> &
+    RefAttributes<HTMLDivElement>
+) => JSX.Element
+
+const TextFieldElement = forwardRef(function TextFieldElement<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: TextFieldElementProps<TFieldValues, TName>,
+  ref: Ref<HTMLDivElement>
+): JSX.Element {
+  const {
+    validation = {},
+    parseError,
+    type,
+    required,
+    name,
+    control,
+    component: TextFieldComponent = TextField,
+    inputRef,
+    ...rest
+  } = props
+
   const errorMsgFn = useFormError()
   const customErrorFn = parseError || errorMsgFn
-  if (required && !validation.required) {
-    validation.required = 'This field is required'
+
+  const rules = {
+    ...validation,
+    ...(required &&
+      !validation.required && {required: 'This field is required'}),
+    ...(type === 'email' &&
+      !validation.pattern && {
+        pattern: {
+          value:
+            // eslint-disable-next-line no-useless-escape
+            /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+          message: 'Please enter a valid email address',
+        },
+      }),
   }
 
-  if (type === 'email' && !validation.pattern) {
-    validation.pattern = {
-      value:
-        // eslint-disable-next-line no-useless-escape
-        /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
-      message: 'Please enter a valid email address',
-    }
-  }
+  const {
+    field,
+    fieldState: {error},
+  } = useController({
+    name,
+    control,
+    rules,
+  })
+
+  const handleInputRef = useForkRef(field.ref, inputRef)
 
   return (
-    <Controller
-      name={name}
-      control={control}
-      rules={validation}
-      render={({
-        field: {value, onChange, onBlur, ref},
-        fieldState: {error},
-      }) => (
-        <TextFieldComponent
-          {...rest}
-          name={name}
-          value={value ?? ''}
-          onChange={(ev) => {
-            onChange(
-              type === 'number' && ev.target.value
-                ? +ev.target.value
-                : ev.target.value
-            )
-            if (typeof rest.onChange === 'function') {
-              rest.onChange(ev)
-            }
-          }}
-          onBlur={onBlur}
-          required={required}
-          type={type}
-          error={!!error}
-          helperText={
-            error
-              ? typeof customErrorFn === 'function'
-                ? customErrorFn(error)
-                : error.message
-              : rest.helperText
-          }
-          inputRef={ref}
-        />
-      )}
+    <TextFieldComponent
+      {...rest}
+      name={field.name}
+      value={field.value ?? ''}
+      onChange={(ev) => {
+        field.onChange(
+          type === 'number' && ev.target.value
+            ? +ev.target.value
+            : ev.target.value
+        )
+        if (typeof rest.onChange === 'function') {
+          rest.onChange(ev)
+        }
+      }}
+      onBlur={field.onBlur}
+      required={required}
+      type={type}
+      error={!!error}
+      helperText={
+        error
+          ? typeof customErrorFn === 'function'
+            ? customErrorFn(error)
+            : error.message
+          : rest.helperText
+      }
+      ref={ref}
+      inputRef={handleInputRef}
     />
   )
-}
+}) as TextFieldElementComponent
+
+export default TextFieldElement

--- a/packages/rhf-mui/src/TextFieldElement.tsx
+++ b/packages/rhf-mui/src/TextFieldElement.tsx
@@ -62,13 +62,13 @@ const TextFieldElement = forwardRef(function TextFieldElement<
       !validation.required && {required: 'This field is required'}),
     ...(type === 'email' &&
       !validation.pattern && {
-        pattern: {
-          value:
+      pattern: {
+        value:
             // eslint-disable-next-line no-useless-escape
             /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
-          message: 'Please enter a valid email address',
-        },
-      }),
+        message: 'Please enter a valid email address',
+      },
+    }),
   }
 
   const {

--- a/packages/rhf-mui/src/TextFieldElement.tsx
+++ b/packages/rhf-mui/src/TextFieldElement.tsx
@@ -14,7 +14,7 @@ export type TextFieldElementProps<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
 > = Omit<TextFieldProps, 'name'> & {
-  validation: UseControllerProps<TFieldValues, TName>['rules']
+  validation?: UseControllerProps<TFieldValues, TName>['rules']
   name: TName
   parseError?: (error: FieldError) => ReactNode
   control?: Control<TFieldValues>

--- a/packages/rhf-mui/src/TimePickerElement.tsx
+++ b/packages/rhf-mui/src/TimePickerElement.tsx
@@ -5,15 +5,16 @@ import {
 } from '@mui/x-date-pickers/TimePicker'
 import {
   Control,
-  Controller,
-  ControllerProps,
   FieldError,
-  Path,
+  FieldValues,
+  FieldPath,
+  PathValue,
+  UseControllerProps,
+  useController,
 } from 'react-hook-form'
-import {TextFieldProps} from '@mui/material'
-import {FieldValues} from 'react-hook-form/dist/types/fields'
+import {TextFieldProps, useForkRef} from '@mui/material'
 import {useFormError} from './FormErrorProvider'
-import {ReactNode} from 'react'
+import {ReactNode, forwardRef, RefAttributes, Ref} from 'react'
 import {
   useLocalizationContext,
   validateTime,
@@ -21,16 +22,16 @@ import {
 import {defaultErrorMessages} from './messages/TimePicker'
 
 export type TimePickerElementProps<
-  T extends FieldValues,
-  TInputDate,
-  TDate = TInputDate
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TDate = PathValue<TFieldValues, TName>
 > = Omit<TimePickerProps<TDate>, 'value' | 'renderInput'> & {
-  name: Path<T>
+  name: TName
   required?: boolean
   isDate?: boolean
   parseError?: (error: FieldError) => ReactNode
-  validation?: ControllerProps<T>['rules']
-  control?: Control<T>
+  validation?: UseControllerProps<TFieldValues, TName>['rules']
+  control?: Control<TFieldValues>
   inputProps?: TextFieldProps
   helperText?: TextFieldProps['helperText']
   textReadOnly?: boolean
@@ -38,108 +39,132 @@ export type TimePickerElementProps<
   overwriteErrorMessages?: typeof defaultErrorMessages
 }
 
-export default function TimePickerElement<TFieldValues extends FieldValues>({
-  parseError,
-  name,
-  required,
-  validation = {},
-  inputProps,
-  control,
-  textReadOnly,
-  slotProps,
-  overwriteErrorMessages,
-  ...rest
-}: TimePickerElementProps<TFieldValues, string | null>): JSX.Element {
+type TimePickerElementComponent = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: TimePickerElementProps<TFieldValues, TName> &
+    RefAttributes<HTMLDivElement>
+) => JSX.Element
+
+const TimePickerElement = forwardRef(function TimePickerElement<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: TimePickerElementProps<TFieldValues, TName>,
+  ref: Ref<HTMLDivElement>
+): JSX.Element {
+  const {
+    parseError,
+    name,
+    required,
+    validation = {},
+    inputProps,
+    control,
+    textReadOnly,
+    slotProps,
+    overwriteErrorMessages,
+    inputRef,
+    ...rest
+  } = props
+
+  const adapter = useLocalizationContext()
+
+  const errorMsgFn = useFormError()
+  const customErrorFn = parseError || errorMsgFn
   const errorMessages = {
     ...defaultErrorMessages,
     ...overwriteErrorMessages,
   }
-  const errorMsgFn = useFormError()
-  const adapter = useLocalizationContext()
 
-  const customErrorFn = parseError || errorMsgFn
-  if (required && !validation.required) {
-    validation.required = 'This field is required'
+  const rules = {
+    ...validation,
+    ...(required &&
+      !validation.required && {
+      required: 'This field is required',
+    }),
+    validate: {
+      internal: (value) => {
+        const inputTimezone =
+          value == null || !adapter.utils.isValid(value)
+            ? null
+            : adapter.utils.getTimezone(value)
+
+        const internalError = validateTime({
+          props: {
+            minTime: rest.minTime,
+            maxTime: rest.maxTime,
+            minutesStep: rest.minutesStep,
+            shouldDisableClock: rest.shouldDisableClock,
+            shouldDisableTime: rest.shouldDisableTime,
+            disableIgnoringDatePartForTimeValidation:
+              rest.disableIgnoringDatePartForTimeValidation,
+            disablePast: Boolean(rest.disablePast),
+            disableFuture: Boolean(rest.disableFuture),
+            timezone: rest.timezone ?? inputTimezone ?? 'default',
+          },
+          value,
+          adapter,
+        })
+        return internalError == null || errorMessages[internalError]
+      },
+      ...validation.validate,
+    },
   }
 
-  validation.validate = {
-    internal: (value) => {
-      const inputTimezone =
-        value == null || !adapter.utils.isValid(value)
-          ? null
-          : adapter.utils.getTimezone(value)
+  const {
+    field,
+    fieldState: {error},
+  } = useController({
+    name,
+    control,
+    rules,
+    defaultValue: null as any,
+  })
 
-      const internalError = validateTime({
-        props: {
-          minTime: rest.minTime,
-          maxTime: rest.maxTime,
-          minutesStep: rest.minutesStep,
-          shouldDisableClock: rest.shouldDisableClock,
-          shouldDisableTime: rest.shouldDisableTime,
-          disableIgnoringDatePartForTimeValidation:
-            rest.disableIgnoringDatePartForTimeValidation,
-          disablePast: Boolean(rest.disablePast),
-          disableFuture: Boolean(rest.disableFuture),
-          timezone: rest.timezone ?? inputTimezone ?? 'default',
-        },
-        value,
-        adapter,
-      })
-      return internalError == null || errorMessages[internalError]
-    },
-    ...validation.validate,
+  const handleInputRef = useForkRef(field.ref, inputRef)
+
+  if (field?.value && typeof field?.value === 'string') {
+    field.value = new Date(field.value) as any // need to see if this works for all localization adaptors
   }
 
   return (
-    <Controller
-      name={name}
-      rules={validation}
-      control={control}
-      defaultValue={null as any}
-      render={({field, fieldState: {error}}) => {
-        if (field?.value && typeof field?.value === 'string') {
-          field.value = new Date(field.value) as any // need to see if this works for all localization adaptors
+    <TimePicker
+      {...rest}
+      {...field}
+      ref={ref}
+      inputRef={handleInputRef}
+      onClose={(...args) => {
+        field.onBlur()
+        if (rest.onClose) {
+          rest.onClose(...args)
         }
-        return (
-          <TimePicker
-            {...rest}
-            {...field}
-            ref={(r) => {
-              field.ref(r?.querySelector('input'))
-            }}
-            onClose={(...args) => {
-              field.onBlur()
-              if (rest.onClose) {
-                rest.onClose(...args)
-              }
-            }}
-            onChange={(v, keyboardInputValue) => {
-              // console.log(v, keyboardInputValue)
-              field.onChange(v, keyboardInputValue)
-              if (typeof rest.onChange === 'function') {
-                rest.onChange(v, keyboardInputValue)
-              }
-            }}
-            slotProps={{
-              ...slotProps,
-              textField: {
-                ...inputProps,
-                required,
-                error: !!error,
-                helperText: error
-                  ? typeof customErrorFn === 'function'
-                    ? customErrorFn(error)
-                    : error.message
-                  : inputProps?.helperText || rest.helperText,
-                inputProps: {
-                  readOnly: textReadOnly,
-                  ...inputProps?.inputProps,
-                },
-              },
-            }}
-          />
-        )
+      }}
+      onChange={(v, keyboardInputValue) => {
+        field.onChange(v, keyboardInputValue)
+        if (typeof rest.onChange === 'function') {
+          rest.onChange(v, keyboardInputValue)
+        }
+      }}
+      slotProps={{
+        ...slotProps,
+        textField: {
+          ...inputProps,
+          required,
+          error: !!error,
+          helperText: error
+            ? typeof customErrorFn === 'function'
+              ? customErrorFn(error)
+              : error.message
+            : inputProps?.helperText || rest.helperText,
+          inputProps: {
+            readOnly: textReadOnly,
+            ...inputProps?.inputProps,
+          },
+        },
       }}
     />
   )
-}
+}) as TimePickerElementComponent
+
+export default TimePickerElement

--- a/packages/rhf-mui/src/ToggleButtonGroupElement.tsx
+++ b/packages/rhf-mui/src/ToggleButtonGroupElement.tsx
@@ -1,11 +1,11 @@
 import {
   Control,
-  Controller,
-  ControllerProps,
   FieldError,
-  Path,
+  FieldPath,
+  UseControllerProps,
+  useController,
+  FieldValues,
 } from 'react-hook-form'
-import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {
   FormControl,
   FormHelperText,
@@ -24,99 +24,108 @@ type SingleToggleButtonProps = Omit<ToggleButtonProps, 'value' | 'children'> & {
   label: ReactNode
 }
 
-export type ToggleButtonGroupElementProps<T extends FieldValues> =
-  ToggleButtonGroupProps & {
-    required?: boolean
-    label?: string
-    validation?: ControllerProps<T>['rules']
-    name: Path<T>
-    parseError?: (error: FieldError) => ReactNode
-    control?: Control<T>
-    options: SingleToggleButtonProps[]
-    formLabelProps?: FormLabelProps
-    helperText?: string
-    enforceAtLeastOneSelected?: boolean
-  }
+export type ToggleButtonGroupElementProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = ToggleButtonGroupProps & {
+  required?: boolean
+  label?: string
+  validation?: UseControllerProps<TFieldValues, TName>['rules']
+  name: TName
+  parseError?: (error: FieldError) => ReactNode
+  control?: Control<TFieldValues>
+  options: SingleToggleButtonProps[]
+  formLabelProps?: FormLabelProps
+  helperText?: string
+  enforceAtLeastOneSelected?: boolean
+}
 
 export default function ToggleButtonGroupElement<
-  TFieldValues extends FieldValues = FieldValues
->({
-  name,
-  control,
-  label,
-  validation = {},
-  required,
-  options = [],
-  parseError,
-  helperText,
-  formLabelProps,
-  enforceAtLeastOneSelected = false,
-  exclusive,
-  ...toggleButtonGroupProps
-}: ToggleButtonGroupElementProps<TFieldValues>) {
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(props: ToggleButtonGroupElementProps<TFieldValues, TName>) {
+  const {
+    name,
+    control,
+    label,
+    validation = {},
+    required,
+    options = [],
+    parseError,
+    helperText,
+    formLabelProps,
+    enforceAtLeastOneSelected = false,
+    exclusive,
+    ...toggleButtonGroupProps
+  } = props
   const errorMsgFn = useFormError()
   const customErrorFn = parseError || errorMsgFn
-  if (required && !validation.required) {
-    validation.required = 'This field is required'
+
+  const rules = {
+    ...validation,
+    ...(required &&
+      !validation.required && {
+      validation: 'This field is required',
+    }),
   }
 
   const isRequired = required || !!validation?.required
+
+  const {
+    field,
+    fieldState: {error},
+  } = useController({
+    name,
+    control,
+    rules,
+  })
+
+  const renderHelperText = error
+    ? typeof customErrorFn === 'function'
+      ? customErrorFn(error)
+      : error.message
+    : helperText
+
   return (
-    <Controller
-      name={name}
-      control={control}
-      rules={validation}
-      render={({field: {value, onChange, onBlur}, fieldState: {error}}) => {
-        const renderHelperText = error
-          ? typeof customErrorFn === 'function'
-            ? customErrorFn(error)
-            : error.message
-          : helperText
-        return (
-          <FormControl
-            error={!!error}
-            required={isRequired}
-            fullWidth={toggleButtonGroupProps?.fullWidth}
-          >
-            {label && (
-              <FormLabel
-                {...formLabelProps}
-                error={!!error}
-                required={isRequired}
-                sx={{mb: 1, ...formLabelProps?.sx}}
-              >
-                {label}
-              </FormLabel>
-            )}
-            <ToggleButtonGroup
-              {...toggleButtonGroupProps}
-              exclusive={exclusive}
-              value={value}
-              onBlur={onBlur}
-              onChange={(event, val) => {
-                if (enforceAtLeastOneSelected) {
-                  // don't allow unselecting the last item
-                  if (exclusive && val === null) return
-                  if (!exclusive && val.length === 0) return
-                }
-                onChange(val)
-                if (typeof toggleButtonGroupProps.onChange === 'function') {
-                  toggleButtonGroupProps.onChange(event, val)
-                }
-              }}
-            >
-              {options.map(({label, id, ...toggleProps}) => (
-                <ToggleButton value={id} {...toggleProps} key={id}>
-                  {label}
-                </ToggleButton>
-              ))}
-            </ToggleButtonGroup>
-            {renderHelperText && (
-              <FormHelperText>{renderHelperText}</FormHelperText>
-            )}
-          </FormControl>
-        )
-      }}
-    />
+    <FormControl
+      error={!!error}
+      required={isRequired}
+      fullWidth={toggleButtonGroupProps?.fullWidth}
+    >
+      {label && (
+        <FormLabel
+          {...formLabelProps}
+          error={!!error}
+          required={isRequired}
+          sx={{mb: 1, ...formLabelProps?.sx}}
+        >
+          {label}
+        </FormLabel>
+      )}
+      <ToggleButtonGroup
+        {...toggleButtonGroupProps}
+        exclusive={exclusive}
+        value={field.value}
+        onBlur={field.onBlur}
+        onChange={(event, val) => {
+          if (enforceAtLeastOneSelected) {
+            // don't allow unselecting the last item
+            if (exclusive && val === null) return
+            if (!exclusive && val.length === 0) return
+          }
+          field.onChange(val)
+          if (typeof toggleButtonGroupProps.onChange === 'function') {
+            toggleButtonGroupProps.onChange(event, val)
+          }
+        }}
+      >
+        {options.map(({label, id, ...toggleProps}) => (
+          <ToggleButton value={id} {...toggleProps} key={id}>
+            {label}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+      {renderHelperText && <FormHelperText>{renderHelperText}</FormHelperText>}
+    </FormControl>
   )
 }


### PR DESCRIPTION
This PR includes the following changes.

- Replaced Controller with useController for all of the components
- allow ref and inputRef prop using useController, useForkRef and forwardRef 
- inputRef prop is allowed for only those components that support it.
- Fix switchProps.onChange [#203](https://github.com/dohomi/react-hook-form-mui/issues/203)
- Added eslint --fix to run after prettier during each commit. (Reason: indent behavior of prettier is conflicting with eslint. https://stackoverflow.com/questions/43301014/eslint-expected-indentation-of-1-tab-but-found-4-spaces-error)  