### PR TITLE
Fix: apply inputProps to TextareaAutosizeElement

### DIFF
--- a/packages/rhf-mui/src/TextareaAutosizeElement.tsx
+++ b/packages/rhf-mui/src/TextareaAutosizeElement.tsx
@@ -50,6 +50,7 @@ const TextareaAutosizeElement = forwardRef(function TextareaAutosizeElement<
     rows,
     resizeStyle,
     inputRef,
+    inputProps,
     ...rest
   } = props
 
@@ -103,6 +104,7 @@ const TextareaAutosizeElement = forwardRef(function TextareaAutosizeElement<
           style: {
             resize: resizeStyle || 'both',
           },
+          ...(inputProps || {}),
         },
       }}
       ref={ref}


### PR DESCRIPTION
With this commit "inputProps" prop passed to TextareaAutosizeElement component applies to inner TextField component.