### PR TITLE
Custom value transform for TextFieldElement

### DIFF
--- a/packages/rhf-mui/src/TextFieldElement.tsx
+++ b/packages/rhf-mui/src/TextFieldElement.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-hook-form'
 import {useFormError} from './FormErrorProvider'
 import {forwardRef, ReactNode, Ref, RefAttributes} from 'react'
+import useTransform, {UseTransformOptions} from './useTransform'
 
 export type TextFieldElementProps<
   TFieldValues extends FieldValues = FieldValues,
@@ -24,6 +25,7 @@ export type TextFieldElementProps<
    * This is especially useful when you want to use a customized version of TextField.
    */
   component?: typeof TextField
+  transform?: UseTransformOptions<TFieldValues, TName>['transform']
 }
 
 type TextFieldElementComponent = <
@@ -50,6 +52,7 @@ const TextFieldElement = forwardRef(function TextFieldElement<
     control,
     component: TextFieldComponent = TextField,
     inputRef,
+    transform,
     ...rest
   } = props
 
@@ -79,6 +82,11 @@ const TextFieldElement = forwardRef(function TextFieldElement<
     control,
     rules,
   })
+  const {value, onChange} = useTransform({
+    value: field.value,
+    onChange: field.onChange,
+    transform,
+  })
 
   const handleInputRef = useForkRef(field.ref, inputRef)
 
@@ -86,9 +94,9 @@ const TextFieldElement = forwardRef(function TextFieldElement<
     <TextFieldComponent
       {...rest}
       name={field.name}
-      value={field.value ?? ''}
+      value={value ?? ''}
       onChange={(ev) => {
-        field.onChange(
+        onChange(
           type === 'number' && ev.target.value
             ? +ev.target.value
             : ev.target.value

--- a/packages/rhf-mui/src/useTransform.ts
+++ b/packages/rhf-mui/src/useTransform.ts
@@ -1,0 +1,51 @@
+import {
+  FieldPath,
+  FieldValues,
+  PathValue,
+  UseControllerReturn,
+} from 'react-hook-form'
+
+export type UseTransformOptions<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = {
+  value: UseControllerReturn<TFieldValues, TName>['field']['value']
+  onChange: UseControllerReturn<TFieldValues, TName>['field']['onChange']
+  transform?: {
+    input?: (
+      value: PathValue<TFieldValues, TName>
+    ) => PathValue<TFieldValues, TName>
+    output?: (...event: any[]) => PathValue<TFieldValues, TName>
+  }
+}
+
+export type UseTransformReturn<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = {
+  value: UseControllerReturn<TFieldValues, TName>['field']['value']
+  onChange: UseControllerReturn<TFieldValues, TName>['field']['onChange']
+}
+
+export default function useTransform<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(options: UseTransformOptions<TFieldValues, TName>): UseTransformReturn {
+  const value =
+    typeof options.transform?.input === 'function'
+      ? options.transform.input(options.value)
+      : options.value
+
+  const onChange = (...event: any[]): void => {
+    if (typeof options.transform?.output === 'function') {
+      options.onChange(options.transform.output(...event))
+    } else {
+      options.onChange(...event)
+    }
+  }
+
+  return {
+    value,
+    onChange,
+  }
+}

--- a/packages/rhf-mui/src/useTransform.ts
+++ b/packages/rhf-mui/src/useTransform.ts
@@ -30,7 +30,9 @@ export type UseTransformReturn<
 export default function useTransform<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
->(options: UseTransformOptions<TFieldValues, TName>): UseTransformReturn {
+>(
+  options: UseTransformOptions<TFieldValues, TName>
+): UseTransformReturn<TFieldValues, TName> {
   const value =
     typeof options.transform?.input === 'function'
       ? options.transform.input(options.value)


### PR DESCRIPTION
This PR is inspired by #175 and https://www.react-hook-form.com/advanced-usage/#TransformandParse.

Changes:
Added transform prop to the TextFieldElement component, enabling users to transform input and output values.

Example usage:
```jsx
<TextFieldElement
  label="Transform"
  name="Transform"
  required
  transform={{
    // Transform input value (number) from react-hook-form to string:
    input: (value) => value.toString(),
    // Transform output value (string) during onChange event to number:
    output: (value) => +value,
  }}
/>
```

@dohomi If the proposed changes are fine, then we can add transform prop to other components as well.