### PR TITLE
fix: required validation in ToggleButtonGroupElement

### DIFF
--- a/packages/rhf-mui/src/ToggleButtonGroupElement.tsx
+++ b/packages/rhf-mui/src/ToggleButtonGroupElement.tsx
@@ -74,7 +74,7 @@ export default function ToggleButtonGroupElement<
     ...validation,
     ...(required &&
       !validation.required && {
-        validation: 'This field is required',
+        required: 'This field is required',
       }),
   }
 


### PR DESCRIPTION
This PR fixes the required validation for ToggleButtonGroupElement and closes [#239](
https://github.com/dohomi/react-hook-form-mui/issues/239)