### PR TITLE
Correctly set `<RadioButtonGroup type="number">` value as a number

### DIFF
--- a/packages/rhf-mui/src/RadioButtonGroup.tsx
+++ b/packages/rhf-mui/src/RadioButtonGroup.tsx
@@ -98,7 +98,8 @@ const RadioButtonGroup = forwardRef(function RadioButtonGroup<
     : helperText
 
   const onRadioChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const radioValue = (event.target as HTMLInputElement).value
+    const target = event.target as HTMLInputElement
+    const radioValue = type === 'number' ? Number(target.value) : target.value
     const returnValue = returnObject
       ? options.find((items) => items[valueKey] === radioValue)
       : radioValue

--- a/packages/rhf-mui/src/RadioButtonGroup.tsx
+++ b/packages/rhf-mui/src/RadioButtonGroup.tsx
@@ -98,8 +98,8 @@ const RadioButtonGroup = forwardRef(function RadioButtonGroup<
     : helperText
 
   const onRadioChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const target = event.target as HTMLInputElement
-    const radioValue = type === 'number' ? Number(target.value) : target.value
+    const radioValue =
+      type === 'number' ? Number(event.target.value) : event.target.value
     const returnValue = returnObject
       ? options.find((items) => items[valueKey] === radioValue)
       : radioValue


### PR DESCRIPTION
When using `<RadioButtonGroup type="number">`, the `value` should be set as a `number` type. However, it is currently being set as a `string` type.

## Steps to Reproduce

1. Go to the [Value As Number story](https://react-hook-form-material-ui.vercel.app/?path=/story/radiobuttongroup--value-as-number) of `RadioButtonGroup`.
2. Click the "Label 1" radio button.
3. Click the submit button.
4. The value is submitted as the string `"1"` instead of the number `1`.

<img width="600" alt="RadioButtonGroup_-_Value_As_Number_⋅_Storybook" src="https://github.com/dohomi/react-hook-form-mui/assets/6268183/07d87cd1-3803-46c8-9687-064bf2394d3f">

## Fix Description

Before calling `field.onChange(value)`, the `value` is now converted to a number type if `type="number"`. 

<img width="600" alt="RadioButtonGroup_-_Value_As_Number_⋅_Storybook" src="https://github.com/dohomi/react-hook-form-mui/assets/6268183/db67326c-a49f-42cc-90c0-a688fe206da3">


