### PR TITLE
Update SingleToggleButtonProps in ToggleButtonGroupElement.tsx

### DIFF
--- a/packages/rhf-mui/src/ToggleButtonGroupElement.tsx
+++ b/packages/rhf-mui/src/ToggleButtonGroupElement.tsx
@@ -21,7 +21,10 @@ import {MouseEvent, ReactNode} from 'react'
 import {useFormError} from './FormErrorProvider'
 import {useTransform} from './useTransform'
 
-type SingleToggleButtonProps = Omit<ToggleButtonProps, 'value' | 'children'> & {
+type SingleToggleButtonProps = Omit<
+  ToggleButtonProps,
+  'id' | 'value' | 'children'
+> & {
   id: number | string
   label: ReactNode
 }


### PR DESCRIPTION
Fixed typing on id prop, which didn't allow for number values due to unintentially inheriting the type from default HTML attributes