### PR TITLE
Bump @mui/x-date-pickers to 7.17.0 for updated validation import paths

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -18,7 +18,7 @@
     "@mui/icons-material": "6.0.1",
     "@mui/material": "6.0.1",
     "@mui/system": "6.0.1",
-    "@mui/x-date-pickers": "7.15.0",
+    "@mui/x-date-pickers": "7.17.0",
     "eslint": "^8",
     "next": "14.2.10",
     "react": "18.3.1",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -41,7 +41,7 @@
     "@mui/icons-material": "6.0.1",
     "@mui/material": "6.0.1",
     "@mui/system": "6.0.1",
-    "@mui/x-date-pickers": "7.15.0",
+    "@mui/x-date-pickers": "7.17.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-hook-form-mui": "portal:../../packages/rhf-mui"

--- a/packages/rhf-mui/package.json
+++ b/packages/rhf-mui/package.json
@@ -3,15 +3,26 @@
   "license": "MIT",
   "repository": "https://github.com/dohomi/react-hook-form-mui",
   "homepage": "https://react-hook-form-material-ui.vercel.app",
-  "keywords": ["react", "mui", "material-ui", "react-hook-form"],
-  "workspaces": ["apps/*", "packages/*"],
+  "keywords": [
+    "react",
+    "mui",
+    "material-ui",
+    "react-hook-form"
+  ],
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
   "name": "react-hook-form-mui",
   "author": "Dominic Garms",
   "source": "src/index.ts",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/index.d.ts",
-  "files": ["dist/**", "src/**"],
+  "files": [
+    "dist/**",
+    "src/**"
+  ],
   "exports": {
     "./package.json": "./package.json",
     ".": {
@@ -46,7 +57,7 @@
   "peerDependencies": {
     "@mui/icons-material": ">= 5.x <7",
     "@mui/material": ">= 5.x <7",
-    "@mui/x-date-pickers": ">=7.0.0 <8",
+    "@mui/x-date-pickers": ">=7.17.0 <8",
     "react": ">=17 <19",
     "react-hook-form": ">=7.33.1"
   },
@@ -66,7 +77,7 @@
     "@mui/icons-material": "6.0.1",
     "@mui/material": "6.0.1",
     "@mui/system": "6.0.1",
-    "@mui/x-date-pickers": "7.15.0",
+    "@mui/x-date-pickers": "7.17.0",
     "@swc/core": "^1.3.17",
     "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.5",

--- a/packages/rhf-mui/src/DatePickerElement.tsx
+++ b/packages/rhf-mui/src/DatePickerElement.tsx
@@ -1,9 +1,4 @@
 import {
-  DatePicker,
-  DatePickerProps,
-  DatePickerSlotProps,
-} from '@mui/x-date-pickers/DatePicker'
-import {
   Control,
   FieldError,
   FieldPath,
@@ -11,51 +6,52 @@ import {
   PathValue,
   useController,
   UseControllerProps,
-} from 'react-hook-form'
-import {TextFieldProps, useForkRef} from '@mui/material'
-import {useFormError} from './FormErrorProvider'
-import {forwardRef, ReactNode, Ref, RefAttributes} from 'react'
+} from "react-hook-form";
+import { TextFieldProps, useForkRef } from "@mui/material";
+import { useFormError } from "./FormErrorProvider";
+import { forwardRef, ReactNode, Ref, RefAttributes } from "react";
 import {
+  DatePicker,
+  DatePickerProps,
+  DatePickerSlotProps,
   DateValidationError,
   PickerChangeHandlerContext,
-} from '@mui/x-date-pickers'
-import {defaultErrorMessages} from './messages/DatePicker'
-import {
-  useLocalizationContext,
   validateDate,
-} from '@mui/x-date-pickers/internals'
-import {useTransform} from './useTransform'
-import {getTimezone} from './utils'
-import {PickerValidDate} from '@mui/x-date-pickers/models'
+} from "@mui/x-date-pickers";
+import { useLocalizationContext } from "@mui/x-date-pickers/internals";
+import { defaultErrorMessages } from "./messages/DatePicker";
+import { useTransform } from "./useTransform";
+import { getTimezone } from "./utils";
+import { PickerValidDate } from "@mui/x-date-pickers/models";
 
 export type DatePickerElementProps<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
   TValue extends PickerValidDate = PickerValidDate,
   TEnableAccessibleFieldDOMStructure extends boolean = false,
-> = Omit<DatePickerProps<TValue>, 'value' | 'slotProps'> & {
-  name: TName
-  required?: boolean
-  isDate?: boolean
-  parseError?: (error: FieldError | DateValidationError) => ReactNode
-  rules?: UseControllerProps<TFieldValues, TName>['rules']
-  control?: Control<TFieldValues>
-  inputProps?: TextFieldProps
-  helperText?: TextFieldProps['helperText']
-  textReadOnly?: boolean
+> = Omit<DatePickerProps<TValue>, "value" | "slotProps"> & {
+  name: TName;
+  required?: boolean;
+  isDate?: boolean;
+  parseError?: (error: FieldError | DateValidationError) => ReactNode;
+  rules?: UseControllerProps<TFieldValues, TName>["rules"];
+  control?: Control<TFieldValues>;
+  inputProps?: TextFieldProps;
+  helperText?: TextFieldProps["helperText"];
+  textReadOnly?: boolean;
   slotProps?: Omit<
     DatePickerSlotProps<TValue, TEnableAccessibleFieldDOMStructure>,
-    'textField'
-  >
-  overwriteErrorMessages?: typeof defaultErrorMessages
+    "textField"
+  >;
+  overwriteErrorMessages?: typeof defaultErrorMessages;
   transform?: {
-    input?: (value: PathValue<TFieldValues, TName>) => TValue | null
+    input?: (value: PathValue<TFieldValues, TName>) => TValue | null;
     output?: (
       value: TValue | null,
       context: PickerChangeHandlerContext<DateValidationError>
-    ) => PathValue<TFieldValues, TName>
-  }
-}
+    ) => PathValue<TFieldValues, TName>;
+  };
+};
 
 type DatePickerElementComponent = <
   TFieldValues extends FieldValues = FieldValues,
@@ -64,7 +60,7 @@ type DatePickerElementComponent = <
 >(
   props: DatePickerElementProps<TFieldValues, TName, TValue> &
     RefAttributes<HTMLDivElement>
-) => JSX.Element
+) => JSX.Element;
 
 const DatePickerElement = forwardRef(function DatePickerElement<
   TFieldValues extends FieldValues = FieldValues,
@@ -87,23 +83,23 @@ const DatePickerElement = forwardRef(function DatePickerElement<
     inputRef,
     transform,
     ...rest
-  } = props
+  } = props;
 
-  const adapter = useLocalizationContext()
+  const adapter = useLocalizationContext();
 
-  const errorMsgFn = useFormError()
-  const customErrorFn = parseError || errorMsgFn
+  const errorMsgFn = useFormError();
+  const customErrorFn = parseError || errorMsgFn;
 
   const errorMessages = {
     ...defaultErrorMessages,
     ...overwriteErrorMessages,
-  }
+  };
 
   const rulesTmp = {
     ...rules,
     ...(required &&
       !rules.required && {
-        required: 'This field is required',
+        required: "This field is required",
       }),
     validate: {
       internal: (value: TValue | null) => {
@@ -116,54 +112,54 @@ const DatePickerElement = forwardRef(function DatePickerElement<
             disableFuture: Boolean(rest.disableFuture),
             minDate: rest.minDate,
             maxDate: rest.maxDate,
-            timezone: rest.timezone ?? getTimezone(adapter, value) ?? 'default',
           },
+          timezone: rest.timezone ?? getTimezone(adapter, value) ?? "default",
           value,
           adapter,
-        })
-        return internalError == null || errorMessages[internalError]
+        });
+        return internalError == null || errorMessages[internalError];
       },
       ...rules.validate,
     },
-  }
+  };
 
   const {
     field,
-    fieldState: {error},
+    fieldState: { error },
   } = useController({
     name,
     control,
     rules: rulesTmp,
     disabled: rest.disabled,
     defaultValue: null as PathValue<TFieldValues, TName>,
-  })
+  });
 
-  const {value, onChange} = useTransform<TFieldValues, TName, TValue | null>({
+  const { value, onChange } = useTransform<TFieldValues, TName, TValue | null>({
     value: field.value,
     onChange: field.onChange,
     transform: {
       input:
-        typeof transform?.input === 'function'
+        typeof transform?.input === "function"
           ? transform.input
           : (newValue) => {
-              return newValue && typeof newValue === 'string'
+              return newValue && typeof newValue === "string"
                 ? (adapter.utils.date(newValue) as unknown as TValue) // need to see if this works for all localization adaptors
-                : newValue
+                : newValue;
             },
       output:
-        typeof transform?.output === 'function'
+        typeof transform?.output === "function"
           ? transform.output
           : (newValue) => newValue,
     },
-  })
+  });
 
-  const handleInputRef = useForkRef(field.ref, inputRef)
+  const handleInputRef = useForkRef(field.ref, inputRef);
 
   const errorMessage = error
-    ? typeof customErrorFn === 'function'
+    ? typeof customErrorFn === "function"
       ? customErrorFn(error)
       : error.message
-    : null
+    : null;
 
   return (
     <DatePicker
@@ -173,15 +169,15 @@ const DatePickerElement = forwardRef(function DatePickerElement<
       ref={ref}
       inputRef={handleInputRef}
       onClose={(...args) => {
-        field.onBlur()
+        field.onBlur();
         if (rest.onClose) {
-          rest.onClose(...args)
+          rest.onClose(...args);
         }
       }}
       onChange={(newValue, context) => {
-        onChange(newValue, context)
-        if (typeof rest.onChange === 'function') {
-          rest.onChange(newValue, context)
+        onChange(newValue, context);
+        if (typeof rest.onChange === "function") {
+          rest.onChange(newValue, context);
         }
       }}
       slotProps={{
@@ -190,9 +186,9 @@ const DatePickerElement = forwardRef(function DatePickerElement<
           ...inputProps,
           required,
           onBlur: (event) => {
-            field.onBlur()
-            if (typeof inputProps?.onBlur === 'function') {
-              inputProps.onBlur(event)
+            field.onBlur();
+            if (typeof inputProps?.onBlur === "function") {
+              inputProps.onBlur(event);
             }
           },
           error: !!errorMessage,
@@ -206,7 +202,7 @@ const DatePickerElement = forwardRef(function DatePickerElement<
         },
       }}
     />
-  )
-})
-DatePickerElement.displayName = 'DatePickerElement'
-export default DatePickerElement as DatePickerElementComponent
+  );
+});
+DatePickerElement.displayName = "DatePickerElement";
+export default DatePickerElement as DatePickerElementComponent;

--- a/packages/rhf-mui/src/DateTimePickerElement.tsx
+++ b/packages/rhf-mui/src/DateTimePickerElement.tsx
@@ -2,7 +2,12 @@ import {
   DateTimePicker,
   DateTimePickerProps,
   DateTimePickerSlotProps,
-} from '@mui/x-date-pickers/DateTimePicker'
+  validateDateTime,
+  DateTimeValidationError,
+  PickerChangeHandlerContext,
+  PickerValidDate,
+} from "@mui/x-date-pickers";
+import { useLocalizationContext } from '@mui/x-date-pickers/internals';
 import {
   Control,
   FieldError,
@@ -10,52 +15,43 @@ import {
   PathValue,
   useController,
   UseControllerProps,
-} from 'react-hook-form'
-import {TextFieldProps, useForkRef} from '@mui/material'
-import {FieldValues} from 'react-hook-form/dist/types/fields'
-import {useFormError} from './FormErrorProvider'
-import {forwardRef, ReactNode, Ref, RefAttributes} from 'react'
-import {defaultErrorMessages} from './messages/DateTimePicker'
-import {
-  useLocalizationContext,
-  validateDateTime,
-} from '@mui/x-date-pickers/internals'
-import {useTransform} from './useTransform'
-import {
-  DateTimeValidationError,
-  PickerChangeHandlerContext,
-} from '@mui/x-date-pickers'
-import {getTimezone} from './utils'
-import {PickerValidDate} from '@mui/x-date-pickers/models'
+} from "react-hook-form";
+import { TextFieldProps, useForkRef } from "@mui/material";
+import { FieldValues } from "react-hook-form/dist/types/fields";
+import { useFormError } from "./FormErrorProvider";
+import { forwardRef, ReactNode, Ref, RefAttributes } from "react";
+import { defaultErrorMessages } from "./messages/DateTimePicker";
+import { useTransform } from "./useTransform";
+import { getTimezone } from "./utils";
 
 export type DateTimePickerElementProps<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
   TValue extends PickerValidDate = PickerValidDate,
   TEnableAccessibleFieldDOMStructure extends boolean = false,
-> = Omit<DateTimePickerProps<TValue>, 'value' | 'slotProps'> & {
-  name: TName
-  required?: boolean
-  isDate?: boolean
-  parseError?: (error: FieldError) => ReactNode
-  rules?: UseControllerProps<TFieldValues, TName>['rules']
-  control?: Control<TFieldValues>
-  inputProps?: TextFieldProps
-  helperText?: TextFieldProps['helperText']
-  textReadOnly?: boolean
+> = Omit<DateTimePickerProps<TValue>, "value" | "slotProps"> & {
+  name: TName;
+  required?: boolean;
+  isDate?: boolean;
+  parseError?: (error: FieldError) => ReactNode;
+  rules?: UseControllerProps<TFieldValues, TName>["rules"];
+  control?: Control<TFieldValues>;
+  inputProps?: TextFieldProps;
+  helperText?: TextFieldProps["helperText"];
+  textReadOnly?: boolean;
   slotProps?: Omit<
     DateTimePickerSlotProps<TValue, TEnableAccessibleFieldDOMStructure>,
-    'textField'
-  >
-  overwriteErrorMessages?: typeof defaultErrorMessages
+    "textField"
+  >;
+  overwriteErrorMessages?: typeof defaultErrorMessages;
   transform?: {
-    input?: (value: PathValue<TFieldValues, TName>) => TValue | null
+    input?: (value: PathValue<TFieldValues, TName>) => TValue | null;
     output?: (
       value: TValue | null,
       context: PickerChangeHandlerContext<DateTimeValidationError>
-    ) => PathValue<TFieldValues, TName>
-  }
-}
+    ) => PathValue<TFieldValues, TName>;
+  };
+};
 
 type DateTimePickerElementComponent = <
   TFieldValues extends FieldValues = FieldValues,
@@ -64,7 +60,7 @@ type DateTimePickerElementComponent = <
 >(
   props: DateTimePickerElementProps<TFieldValues, TName, TValue> &
     RefAttributes<HTMLDivElement>
-) => JSX.Element
+) => JSX.Element;
 
 const DateTimePickerElement = forwardRef(function DateTimePickerElement<
   TFieldValues extends FieldValues = FieldValues,
@@ -87,22 +83,22 @@ const DateTimePickerElement = forwardRef(function DateTimePickerElement<
     inputRef,
     transform,
     ...rest
-  } = props
+  } = props;
 
-  const adapter = useLocalizationContext()
+  const adapter = useLocalizationContext();
 
-  const errorMsgFn = useFormError()
-  const customErrorFn = parseError || errorMsgFn
+  const errorMsgFn = useFormError();
+  const customErrorFn = parseError || errorMsgFn;
   const errorMessages = {
     ...defaultErrorMessages,
     ...overwriteErrorMessages,
-  }
+  };
 
   const rulesTmp = {
     ...rules,
     ...(required &&
       !rules.required && {
-        required: 'This field is required',
+        required: "This field is required",
       }),
     validate: {
       internal: (value: TValue | null) => {
@@ -115,56 +111,56 @@ const DateTimePickerElement = forwardRef(function DateTimePickerElement<
             disableFuture: Boolean(rest.disableFuture),
             minDate: rest.minDate,
             maxDate: rest.maxDate,
-            timezone: rest.timezone ?? getTimezone(adapter, value) ?? 'default',
             disableIgnoringDatePartForTimeValidation:
-              rest.disableIgnoringDatePartForTimeValidation,
+            rest.disableIgnoringDatePartForTimeValidation,
             maxTime: rest.maxTime,
             minTime: rest.minTime,
             minutesStep: rest.minutesStep,
             shouldDisableTime: rest.shouldDisableTime,
           },
+          timezone: rest.timezone ?? getTimezone(adapter, value) ?? "default",
           value,
           adapter,
-        })
+        });
 
-        return internalError == null || errorMessages[internalError]
+        return internalError == null || errorMessages[internalError];
       },
       ...rules.validate,
     },
-  }
+  };
 
   const {
     field,
-    fieldState: {error},
+    fieldState: { error },
   } = useController({
     name,
     rules: rulesTmp,
     control,
     disabled: rest.disabled,
     defaultValue: null as PathValue<TFieldValues, TName>,
-  })
+  });
 
-  const {value, onChange} = useTransform<TFieldValues, TName, TValue | null>({
+  const { value, onChange } = useTransform<TFieldValues, TName, TValue | null>({
     value: field.value,
     onChange: field.onChange,
     transform: {
       input:
-        typeof transform?.input === 'function'
+        typeof transform?.input === "function"
           ? transform.input
           : (newValue) => {
-              return newValue && typeof newValue === 'string'
+              return newValue && typeof newValue === "string"
                 ? (adapter.utils.date(newValue) as unknown as TValue) // need to see if this works for all localization adaptors
-                : newValue
+                : newValue;
             },
       output:
-        typeof transform?.output === 'function'
+        typeof transform?.output === "function"
           ? transform.output
           : (newValue: TValue | null) =>
               newValue as PathValue<TFieldValues, TName>,
     },
-  })
+  });
 
-  const handleInputRef = useForkRef(field.ref, inputRef)
+  const handleInputRef = useForkRef(field.ref, inputRef);
 
   return (
     <DateTimePicker
@@ -174,15 +170,15 @@ const DateTimePickerElement = forwardRef(function DateTimePickerElement<
       ref={ref}
       inputRef={handleInputRef}
       onClose={(...args) => {
-        field.onBlur()
+        field.onBlur();
         if (rest.onClose) {
-          rest.onClose(...args)
+          rest.onClose(...args);
         }
       }}
       onChange={(newValue, context) => {
-        onChange(newValue, context)
-        if (typeof rest.onChange === 'function') {
-          rest.onChange(newValue, context)
+        onChange(newValue, context);
+        if (typeof rest.onChange === "function") {
+          rest.onChange(newValue, context);
         }
       }}
       slotProps={{
@@ -192,7 +188,7 @@ const DateTimePickerElement = forwardRef(function DateTimePickerElement<
           required,
           error: !!error,
           helperText: error
-            ? typeof customErrorFn === 'function'
+            ? typeof customErrorFn === "function"
               ? customErrorFn(error)
               : error.message
             : inputProps?.helperText || rest.helperText,
@@ -203,7 +199,7 @@ const DateTimePickerElement = forwardRef(function DateTimePickerElement<
         },
       }}
     />
-  )
-})
-DateTimePickerElement.displayName = 'DateTimePickerElement'
-export default DateTimePickerElement as DateTimePickerElementComponent
+  );
+});
+DateTimePickerElement.displayName = "DateTimePickerElement";
+export default DateTimePickerElement as DateTimePickerElementComponent;

--- a/packages/rhf-mui/src/MobileDatePickerElement.tsx
+++ b/packages/rhf-mui/src/MobileDatePickerElement.tsx
@@ -2,7 +2,8 @@ import {
   MobileDatePicker,
   MobileDatePickerProps,
   MobileDatePickerSlotProps,
-} from '@mui/x-date-pickers/MobileDatePicker'
+  validateDate,
+} from "@mui/x-date-pickers";
 import {
   Control,
   FieldError,
@@ -11,50 +12,47 @@ import {
   PathValue,
   useController,
   UseControllerProps,
-} from 'react-hook-form'
-import {TextFieldProps, useForkRef} from '@mui/material'
-import {useFormError} from './FormErrorProvider'
-import {forwardRef, ReactNode, Ref, RefAttributes} from 'react'
-import {defaultErrorMessages} from './messages/DatePicker'
-import {
-  useLocalizationContext,
-  validateDate,
-} from '@mui/x-date-pickers/internals'
-import {useTransform} from './useTransform'
+} from "react-hook-form";
+import { TextFieldProps, useForkRef } from "@mui/material";
+import { useFormError } from "./FormErrorProvider";
+import { forwardRef, ReactNode, Ref, RefAttributes } from "react";
+import { defaultErrorMessages } from "./messages/DatePicker";
+import { useLocalizationContext } from "@mui/x-date-pickers/internals";
+import { useTransform } from "./useTransform";
 import {
   DateValidationError,
   PickerChangeHandlerContext,
-} from '@mui/x-date-pickers'
-import {getTimezone} from './utils'
-import {PickerValidDate} from '@mui/x-date-pickers/models'
+} from "@mui/x-date-pickers";
+import { getTimezone } from "./utils";
+import { PickerValidDate } from "@mui/x-date-pickers/models";
 
 export type MobileDatePickerElementProps<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
   TValue extends PickerValidDate = PickerValidDate,
   TEnableAccessibleFieldDOMStructure extends boolean = false,
-> = Omit<MobileDatePickerProps<TValue>, 'value' | 'slotProps'> & {
-  name: TName
-  required?: boolean
-  isDate?: boolean
-  parseError?: (error: FieldError) => ReactNode
-  rules?: UseControllerProps<TFieldValues, TName>['rules']
-  control?: Control<TFieldValues>
-  inputProps?: TextFieldProps
-  helperText?: TextFieldProps['helperText']
+> = Omit<MobileDatePickerProps<TValue>, "value" | "slotProps"> & {
+  name: TName;
+  required?: boolean;
+  isDate?: boolean;
+  parseError?: (error: FieldError) => ReactNode;
+  rules?: UseControllerProps<TFieldValues, TName>["rules"];
+  control?: Control<TFieldValues>;
+  inputProps?: TextFieldProps;
+  helperText?: TextFieldProps["helperText"];
   slotProps?: Omit<
     MobileDatePickerSlotProps<TValue, TEnableAccessibleFieldDOMStructure>,
-    'textField'
-  >
-  overwriteErrorMessages?: typeof defaultErrorMessages
+    "textField"
+  >;
+  overwriteErrorMessages?: typeof defaultErrorMessages;
   transform?: {
-    input?: (value: PathValue<TFieldValues, TName>) => TValue | null
+    input?: (value: PathValue<TFieldValues, TName>) => TValue | null;
     output?: (
       value: TValue | null,
       context: PickerChangeHandlerContext<DateValidationError>
-    ) => PathValue<TFieldValues, TName>
-  }
-}
+    ) => PathValue<TFieldValues, TName>;
+  };
+};
 
 type MobileDatePickerElementComponent = <
   TFieldValues extends FieldValues = FieldValues,
@@ -63,7 +61,7 @@ type MobileDatePickerElementComponent = <
 >(
   props: MobileDatePickerElementProps<TFieldValues, TName, TValue> &
     RefAttributes<HTMLDivElement>
-) => JSX.Element
+) => JSX.Element;
 
 const MobileDatePickerElement = forwardRef(function MobileDatePickerElement<
   TFieldValues extends FieldValues = FieldValues,
@@ -85,23 +83,23 @@ const MobileDatePickerElement = forwardRef(function MobileDatePickerElement<
     inputRef,
     transform,
     ...rest
-  } = props
+  } = props;
 
-  const adapter = useLocalizationContext()
+  const adapter = useLocalizationContext();
 
-  const errorMsgFn = useFormError()
-  const customErrorFn = parseError || errorMsgFn
+  const errorMsgFn = useFormError();
+  const customErrorFn = parseError || errorMsgFn;
 
   const errorMessages = {
     ...defaultErrorMessages,
     ...overwriteErrorMessages,
-  }
+  };
 
   const rulesTmp = {
     ...rules,
     ...(required &&
       !rules.required && {
-        required: 'This field is required',
+        required: "This field is required",
       }),
     validate: {
       internal: (value: TValue | null) => {
@@ -114,48 +112,48 @@ const MobileDatePickerElement = forwardRef(function MobileDatePickerElement<
             disableFuture: Boolean(rest.disableFuture),
             minDate: rest.minDate,
             maxDate: rest.maxDate,
-            timezone: rest.timezone ?? getTimezone(adapter, value) ?? 'default',
           },
+          timezone: rest.timezone ?? getTimezone(adapter, value) ?? "default",
           value,
           adapter,
-        })
-        return internalError == null || errorMessages[internalError]
+        });
+        return internalError == null || errorMessages[internalError];
       },
       ...rules.validate,
     },
-  }
+  };
 
   const {
     field,
-    fieldState: {error},
+    fieldState: { error },
   } = useController({
     name,
     control,
     rules: rulesTmp,
     disabled: rest.disabled,
     defaultValue: null as PathValue<TFieldValues, TName>,
-  })
+  });
 
-  const {value, onChange} = useTransform<TFieldValues, TName, TValue | null>({
+  const { value, onChange } = useTransform<TFieldValues, TName, TValue | null>({
     value: field.value,
     onChange: field.onChange,
     transform: {
       input:
-        typeof transform?.input === 'function'
+        typeof transform?.input === "function"
           ? transform.input
           : (newValue) => {
-              return newValue && typeof newValue === 'string'
+              return newValue && typeof newValue === "string"
                 ? (adapter.utils.date(newValue) as unknown as TValue) // need to see if this works for all localization adaptors
-                : newValue
+                : newValue;
             },
       output:
-        typeof transform?.output === 'function'
+        typeof transform?.output === "function"
           ? transform.output
           : (newValue) => newValue,
     },
-  })
+  });
 
-  const handleInputRef = useForkRef(field.ref, inputRef)
+  const handleInputRef = useForkRef(field.ref, inputRef);
 
   return (
     <MobileDatePicker
@@ -165,15 +163,15 @@ const MobileDatePickerElement = forwardRef(function MobileDatePickerElement<
       ref={ref}
       inputRef={handleInputRef}
       onClose={(...args) => {
-        field.onBlur()
+        field.onBlur();
         if (rest.onClose) {
-          rest.onClose(...args)
+          rest.onClose(...args);
         }
       }}
       onChange={(newValue, context) => {
-        onChange(newValue, context)
-        if (typeof rest.onChange === 'function') {
-          rest.onChange(newValue, context)
+        onChange(newValue, context);
+        if (typeof rest.onChange === "function") {
+          rest.onChange(newValue, context);
         }
       }}
       slotProps={{
@@ -183,14 +181,14 @@ const MobileDatePickerElement = forwardRef(function MobileDatePickerElement<
           required,
           error: !!error,
           helperText: error
-            ? typeof customErrorFn === 'function'
+            ? typeof customErrorFn === "function"
               ? customErrorFn(error)
               : error.message
             : inputProps?.helperText || rest.helperText,
         },
       }}
     />
-  )
-})
-MobileDatePickerElement.displayName = 'MobileDatePickerElement'
-export default MobileDatePickerElement as MobileDatePickerElementComponent
+  );
+});
+MobileDatePickerElement.displayName = "MobileDatePickerElement";
+export default MobileDatePickerElement as MobileDatePickerElementComponent;

--- a/packages/rhf-mui/src/TimePickerElement.tsx
+++ b/packages/rhf-mui/src/TimePickerElement.tsx
@@ -2,7 +2,8 @@ import {
   TimePicker,
   TimePickerProps,
   TimePickerSlotProps,
-} from '@mui/x-date-pickers/TimePicker'
+  validateTime,
+} from "@mui/x-date-pickers";
 import {
   Control,
   FieldError,
@@ -11,51 +12,48 @@ import {
   PathValue,
   useController,
   UseControllerProps,
-} from 'react-hook-form'
-import {TextFieldProps, useForkRef} from '@mui/material'
-import {useFormError} from './FormErrorProvider'
-import {forwardRef, ReactNode, Ref, RefAttributes} from 'react'
-import {
-  useLocalizationContext,
-  validateTime,
-} from '@mui/x-date-pickers/internals'
-import {defaultErrorMessages} from './messages/TimePicker'
-import {useTransform} from './useTransform'
+} from "react-hook-form";
+import { TextFieldProps, useForkRef } from "@mui/material";
+import { useFormError } from "./FormErrorProvider";
+import { forwardRef, ReactNode, Ref, RefAttributes } from "react";
+import { useLocalizationContext } from "@mui/x-date-pickers/internals";
+import { defaultErrorMessages } from "./messages/TimePicker";
+import { useTransform } from "./useTransform";
 import {
   PickerChangeHandlerContext,
   TimeValidationError,
-} from '@mui/x-date-pickers'
-import {getTimezone} from './utils'
-import {PickerValidDate} from '@mui/x-date-pickers/models'
+} from "@mui/x-date-pickers";
+import { getTimezone } from "./utils";
+import { PickerValidDate } from "@mui/x-date-pickers/models";
 
 export type TimePickerElementProps<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
   TValue extends PickerValidDate = PickerValidDate,
   TEnableAccessibleFieldDOMStructure extends boolean = false,
-> = Omit<TimePickerProps<TValue>, 'value' | 'renderInput'> & {
-  name: TName
-  required?: boolean
-  isDate?: boolean
-  parseError?: (error: FieldError) => ReactNode
-  rules?: UseControllerProps<TFieldValues, TName>['rules']
-  control?: Control<TFieldValues>
-  inputProps?: TextFieldProps
-  helperText?: TextFieldProps['helperText']
-  textReadOnly?: boolean
+> = Omit<TimePickerProps<TValue>, "value" | "renderInput"> & {
+  name: TName;
+  required?: boolean;
+  isDate?: boolean;
+  parseError?: (error: FieldError) => ReactNode;
+  rules?: UseControllerProps<TFieldValues, TName>["rules"];
+  control?: Control<TFieldValues>;
+  inputProps?: TextFieldProps;
+  helperText?: TextFieldProps["helperText"];
+  textReadOnly?: boolean;
   slotProps?: Omit<
     TimePickerSlotProps<TValue, TEnableAccessibleFieldDOMStructure>,
-    'textField'
-  >
-  overwriteErrorMessages?: typeof defaultErrorMessages
+    "textField"
+  >;
+  overwriteErrorMessages?: typeof defaultErrorMessages;
   transform?: {
-    input?: (value: PathValue<TFieldValues, TName>) => TValue | null
+    input?: (value: PathValue<TFieldValues, TName>) => TValue | null;
     output?: (
       value: TValue | null,
       context: PickerChangeHandlerContext<TimeValidationError>
-    ) => PathValue<TFieldValues, TName>
-  }
-}
+    ) => PathValue<TFieldValues, TName>;
+  };
+};
 
 type TimePickerElementComponent = <
   TFieldValues extends FieldValues = FieldValues,
@@ -64,7 +62,7 @@ type TimePickerElementComponent = <
 >(
   props: TimePickerElementProps<TFieldValues, TName, TValue> &
     RefAttributes<HTMLDivElement>
-) => JSX.Element
+) => JSX.Element;
 
 const TimePickerElement = forwardRef(function TimePickerElement<
   TFieldValues extends FieldValues = FieldValues,
@@ -87,22 +85,22 @@ const TimePickerElement = forwardRef(function TimePickerElement<
     inputRef,
     transform,
     ...rest
-  } = props
+  } = props;
 
-  const adapter = useLocalizationContext()
+  const adapter = useLocalizationContext();
 
-  const errorMsgFn = useFormError()
-  const customErrorFn = parseError || errorMsgFn
+  const errorMsgFn = useFormError();
+  const customErrorFn = parseError || errorMsgFn;
   const errorMessages = {
     ...defaultErrorMessages,
     ...overwriteErrorMessages,
-  }
+  };
 
   const rulesTmp = {
     ...rules,
     ...(required &&
       !rules.required && {
-        required: 'This field is required',
+        required: "This field is required",
       }),
     validate: {
       internal: (value: TValue | null) => {
@@ -116,48 +114,48 @@ const TimePickerElement = forwardRef(function TimePickerElement<
               rest.disableIgnoringDatePartForTimeValidation,
             disablePast: Boolean(rest.disablePast),
             disableFuture: Boolean(rest.disableFuture),
-            timezone: rest.timezone ?? getTimezone(adapter, value) ?? 'default',
           },
+          timezone: rest.timezone ?? getTimezone(adapter, value) ?? "default",
           value,
           adapter,
-        })
-        return internalError == null || errorMessages[internalError]
+        });
+        return internalError == null || errorMessages[internalError];
       },
       ...rules.validate,
     },
-  }
+  };
 
   const {
     field,
-    fieldState: {error},
+    fieldState: { error },
   } = useController({
     name,
     control,
     rules: rulesTmp,
     disabled: rest.disabled,
     defaultValue: null as PathValue<TFieldValues, TName>,
-  })
+  });
 
-  const {value, onChange} = useTransform<TFieldValues, TName, TValue | null>({
+  const { value, onChange } = useTransform<TFieldValues, TName, TValue | null>({
     value: field.value,
     onChange: field.onChange,
     transform: {
       input:
-        typeof transform?.input === 'function'
+        typeof transform?.input === "function"
           ? transform.input
           : (newValue) => {
-              return newValue && typeof newValue === 'string'
+              return newValue && typeof newValue === "string"
                 ? (adapter.utils.date(newValue) as unknown as TValue) // need to see if this works for all localization adaptors
-                : newValue
+                : newValue;
             },
       output:
-        typeof transform?.output === 'function'
+        typeof transform?.output === "function"
           ? transform.output
           : (newValue) => newValue,
     },
-  })
+  });
 
-  const handleInputRef = useForkRef(field.ref, inputRef)
+  const handleInputRef = useForkRef(field.ref, inputRef);
 
   return (
     <TimePicker
@@ -167,15 +165,15 @@ const TimePickerElement = forwardRef(function TimePickerElement<
       ref={ref}
       inputRef={handleInputRef}
       onClose={(...args) => {
-        field.onBlur()
+        field.onBlur();
         if (rest.onClose) {
-          rest.onClose(...args)
+          rest.onClose(...args);
         }
       }}
       onChange={(value, context) => {
-        onChange(value, context)
-        if (typeof rest.onChange === 'function') {
-          rest.onChange(value, context)
+        onChange(value, context);
+        if (typeof rest.onChange === "function") {
+          rest.onChange(value, context);
         }
       }}
       slotProps={{
@@ -185,7 +183,7 @@ const TimePickerElement = forwardRef(function TimePickerElement<
           required,
           error: !!error,
           helperText: error
-            ? typeof customErrorFn === 'function'
+            ? typeof customErrorFn === "function"
               ? customErrorFn(error)
               : error.message
             : inputProps?.helperText || rest.helperText,
@@ -196,7 +194,7 @@ const TimePickerElement = forwardRef(function TimePickerElement<
         },
       }}
     />
-  )
-})
-TimePickerElement.displayName = 'TimePickerElement'
-export default TimePickerElement as TimePickerElementComponent
+  );
+});
+TimePickerElement.displayName = "TimePickerElement";
+export default TimePickerElement as TimePickerElementComponent;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1405,12 +1405,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.25.4":
+"@babel/runtime@npm:^7.25.0":
   version: 7.25.6
   resolution: "@babel/runtime@npm:7.25.6"
   dependencies:
     regenerator-runtime: "npm:^0.14.0"
   checksum: 10/0c4134734deb20e1005ffb9165bf342e1074576621b246d8e5e41cc7cb315a885b7d98950fbf5c63619a2990a56ae82f444d35fe8c4691a0b70c2fe5673667dc
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.25.6":
+  version: 7.25.7
+  resolution: "@babel/runtime@npm:7.25.7"
+  dependencies:
+    regenerator-runtime: "npm:^0.14.0"
+  checksum: 10/73411fe0f1bff3a962586cef05b30f49e554b6563767e6d84f7d79d605b2c20e7fc3df291a3aebef69043181a8f893afdab9e6672557a5c2d08b9377d6f678cd
   languageName: node
   linkType: hard
 
@@ -2583,12 +2592,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/x-date-pickers@npm:7.15.0":
-  version: 7.15.0
-  resolution: "@mui/x-date-pickers@npm:7.15.0"
+"@mui/x-date-pickers@npm:7.17.0":
+  version: 7.17.0
+  resolution: "@mui/x-date-pickers@npm:7.17.0"
   dependencies:
-    "@babel/runtime": "npm:^7.25.4"
+    "@babel/runtime": "npm:^7.25.6"
     "@mui/utils": "npm:^5.16.6"
+    "@mui/x-internals": "npm:7.17.0"
     "@types/react-transition-group": "npm:^4.4.11"
     clsx: "npm:^2.1.1"
     prop-types: "npm:^15.8.1"
@@ -2626,7 +2636,19 @@ __metadata:
       optional: true
     moment-jalaali:
       optional: true
-  checksum: 10/cb8cc9d306ae5a8f3ea10fbc701c4371905421877067326829ab7e17c070aa99bd5ae2eb662b20bf50d7a639e8eebf91e3ccbda694b61c4518bed28aa1a1fd94
+  checksum: 10/90ad16ed155a43f93d6b074ba422005269e0f7055599426b102b32e2332cde5b19f9cc4cd0edd45ce77e94e5443bf0bda9b5ee2eb23f67d4ee9f54ac41c4dd61
+  languageName: node
+  linkType: hard
+
+"@mui/x-internals@npm:7.17.0":
+  version: 7.17.0
+  resolution: "@mui/x-internals@npm:7.17.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.25.6"
+    "@mui/utils": "npm:^5.16.6"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+  checksum: 10/92b912d955bb6c983e4aa8440581812fa42869a211530e67f00681152a9c7f29bc21fa71c746d3a5f67beb75343923b5cc9bac3c927aa530f2bf81a78df86fc0
   languageName: node
   linkType: hard
 
@@ -9566,7 +9588,7 @@ __metadata:
     "@mui/icons-material": "npm:6.0.1"
     "@mui/material": "npm:6.0.1"
     "@mui/system": "npm:6.0.1"
-    "@mui/x-date-pickers": "npm:7.15.0"
+    "@mui/x-date-pickers": "npm:7.17.0"
     "@next/bundle-analyzer": "npm:latest"
     "@types/eslint": "npm:^8"
     "@types/react": "npm:latest"
@@ -10658,7 +10680,7 @@ __metadata:
   peerDependencies:
     "@mui/icons-material": ">= 5.x <7"
     "@mui/material": ">= 5.x <7"
-    "@mui/x-date-pickers": ">=7.0.0 <8"
+    "@mui/x-date-pickers": ">=7.17.0 <8"
     react: ">=17 <19"
     react-hook-form: ">=7.33.1"
   peerDependenciesMeta:
@@ -10675,7 +10697,7 @@ __metadata:
   peerDependencies:
     "@mui/icons-material": ">= 5.x <7"
     "@mui/material": ">= 5.x <7"
-    "@mui/x-date-pickers": ">=7.0.0 <8"
+    "@mui/x-date-pickers": ">=7.17.0 <8"
     react: ">=17 <19"
     react-hook-form: ">=7.33.1"
   peerDependenciesMeta:
@@ -10697,7 +10719,7 @@ __metadata:
     "@mui/icons-material": "npm:6.0.1"
     "@mui/material": "npm:6.0.1"
     "@mui/system": "npm:6.0.1"
-    "@mui/x-date-pickers": "npm:7.15.0"
+    "@mui/x-date-pickers": "npm:7.17.0"
     "@swc/core": "npm:^1.3.17"
     "@types/react": "npm:^18.0.14"
     "@types/react-dom": "npm:^18.0.5"
@@ -10712,7 +10734,7 @@ __metadata:
   peerDependencies:
     "@mui/icons-material": ">= 5.x <7"
     "@mui/material": ">= 5.x <7"
-    "@mui/x-date-pickers": ">=7.0.0 <8"
+    "@mui/x-date-pickers": ">=7.17.0 <8"
     react: ">=17 <19"
     react-hook-form: ">=7.33.1"
   peerDependenciesMeta:
@@ -11176,7 +11198,7 @@ __metadata:
     "@mui/icons-material": "npm:6.0.1"
     "@mui/material": "npm:6.0.1"
     "@mui/system": "npm:6.0.1"
-    "@mui/x-date-pickers": "npm:7.15.0"
+    "@mui/x-date-pickers": "npm:7.17.0"
     "@storybook/addon-essentials": "npm:8.0.10"
     "@storybook/react": "npm:8.0.10"
     "@storybook/react-vite": "npm:8.0.10"


### PR DESCRIPTION
Fixes #310

- Upgrade @mui/x-date-pickers package to version 7.17.0
- Adjust validation import paths to align with the latest version