### PR TITLE
fix: Checkbox option label not rendering components

### DIFF
--- a/packages/rhf-mui/src/CheckboxButtonGroup.tsx
+++ b/packages/rhf-mui/src/CheckboxButtonGroup.tsx
@@ -188,7 +188,7 @@ const CheckboxButtonGroup = forwardRef(function CheckboxButtonGroup<
                   onChange={() => handleChange(option)}
                 />
               }
-              label={`${optionLabel}`}
+              label={optionLabel as ReactNode}
               key={`${optionValue}`}
             />
           )


### PR DESCRIPTION
Fixes #269

- The CheckboxElement was always rendering the label as a string, so the conversion of the label to a string has been removed.