### PR TITLE
fix: read string value as date in internal validation

### DIFF
--- a/packages/rhf-mui/src/DatePickerElement.tsx
+++ b/packages/rhf-mui/src/DatePickerElement.tsx
@@ -21,7 +21,7 @@ import {
 import { useLocalizationContext } from "@mui/x-date-pickers/internals";
 import { defaultErrorMessages } from "./messages/DatePicker";
 import { useTransform } from "./useTransform";
-import { getTimezone } from "./utils";
+import { getTimezone, readValueAsDate } from "./utils";
 import { PickerValidDate } from "@mui/x-date-pickers/models";
 
 export type DatePickerElementProps<
@@ -103,7 +103,8 @@ const DatePickerElement = forwardRef(function DatePickerElement<
       }),
     validate: {
       internal: (value: TValue | null) => {
-        if(!value){
+        const date = readValueAsDate(adapter, value)
+        if(!date){
           return true
         }
         const internalError = validateDate({
@@ -116,8 +117,8 @@ const DatePickerElement = forwardRef(function DatePickerElement<
             minDate: rest.minDate,
             maxDate: rest.maxDate,
           },
-          timezone: rest.timezone ?? getTimezone(adapter, value) ?? "default",
-          value,
+          timezone: rest.timezone ?? getTimezone(adapter, date) ?? "default",
+          value: date,
           adapter,
         });
         return internalError == null || errorMessages[internalError];
@@ -144,11 +145,7 @@ const DatePickerElement = forwardRef(function DatePickerElement<
       input:
         typeof transform?.input === "function"
           ? transform.input
-          : (newValue) => {
-              return newValue && typeof newValue === "string"
-                ? (adapter.utils.date(newValue) as unknown as TValue) // need to see if this works for all localization adaptors
-                : newValue;
-            },
+          : (newValue) => readValueAsDate(adapter, newValue),
       output:
         typeof transform?.output === "function"
           ? transform.output

--- a/packages/rhf-mui/src/DateTimePickerElement.tsx
+++ b/packages/rhf-mui/src/DateTimePickerElement.tsx
@@ -22,7 +22,7 @@ import { useFormError } from "./FormErrorProvider";
 import { forwardRef, ReactNode, Ref, RefAttributes } from "react";
 import { defaultErrorMessages } from "./messages/DateTimePicker";
 import { useTransform } from "./useTransform";
-import { getTimezone } from "./utils";
+import { getTimezone, readValueAsDate } from "./utils";
 
 export type DateTimePickerElementProps<
   TFieldValues extends FieldValues = FieldValues,
@@ -102,7 +102,8 @@ const DateTimePickerElement = forwardRef(function DateTimePickerElement<
       }),
     validate: {
       internal: (value: TValue | null) => {
-        if(!value){
+        const date = readValueAsDate(adapter, value);
+        if(!date){
           return true
         }
         const internalError = validateDateTime({
@@ -121,8 +122,8 @@ const DateTimePickerElement = forwardRef(function DateTimePickerElement<
             minutesStep: rest.minutesStep,
             shouldDisableTime: rest.shouldDisableTime,
           },
-          timezone: rest.timezone ?? getTimezone(adapter, value) ?? "default",
-          value,
+          timezone: rest.timezone ?? getTimezone(adapter, date) ?? "default",
+          value: date,
           adapter,
         });
 
@@ -150,11 +151,7 @@ const DateTimePickerElement = forwardRef(function DateTimePickerElement<
       input:
         typeof transform?.input === "function"
           ? transform.input
-          : (newValue) => {
-              return newValue && typeof newValue === "string"
-                ? (adapter.utils.date(newValue) as unknown as TValue) // need to see if this works for all localization adaptors
-                : newValue;
-            },
+          : (newValue) => readValueAsDate(adapter, newValue),
       output:
         typeof transform?.output === "function"
           ? transform.output

--- a/packages/rhf-mui/src/MobileDatePickerElement.tsx
+++ b/packages/rhf-mui/src/MobileDatePickerElement.tsx
@@ -23,7 +23,7 @@ import {
   DateValidationError,
   PickerChangeHandlerContext,
 } from "@mui/x-date-pickers";
-import { getTimezone } from "./utils";
+import { getTimezone, readValueAsDate } from "./utils";
 import { PickerValidDate } from "@mui/x-date-pickers/models";
 
 export type MobileDatePickerElementProps<
@@ -103,7 +103,8 @@ const MobileDatePickerElement = forwardRef(function MobileDatePickerElement<
       }),
     validate: {
       internal: (value: TValue | null) => {
-        if(!value){
+        const date = readValueAsDate(adapter, value)
+        if(!date){
           return true
         }
         const internalError = validateDate({
@@ -116,8 +117,8 @@ const MobileDatePickerElement = forwardRef(function MobileDatePickerElement<
             minDate: rest.minDate,
             maxDate: rest.maxDate,
           },
-          timezone: rest.timezone ?? getTimezone(adapter, value) ?? "default",
-          value,
+          timezone: rest.timezone ?? getTimezone(adapter, date) ?? "default",
+          value: date,
           adapter,
         });
         return internalError == null || errorMessages[internalError];
@@ -144,11 +145,7 @@ const MobileDatePickerElement = forwardRef(function MobileDatePickerElement<
       input:
         typeof transform?.input === "function"
           ? transform.input
-          : (newValue) => {
-              return newValue && typeof newValue === "string"
-                ? (adapter.utils.date(newValue) as unknown as TValue) // need to see if this works for all localization adaptors
-                : newValue;
-            },
+          : (newValue) => readValueAsDate(adapter, newValue),
       output:
         typeof transform?.output === "function"
           ? transform.output

--- a/packages/rhf-mui/src/TimePickerElement.tsx
+++ b/packages/rhf-mui/src/TimePickerElement.tsx
@@ -23,7 +23,7 @@ import {
   PickerChangeHandlerContext,
   TimeValidationError,
 } from "@mui/x-date-pickers";
-import { getTimezone } from "./utils";
+import { getTimezone, readValueAsDate } from "./utils";
 import { PickerValidDate } from "@mui/x-date-pickers/models";
 
 export type TimePickerElementProps<
@@ -104,7 +104,8 @@ const TimePickerElement = forwardRef(function TimePickerElement<
       }),
     validate: {
       internal: (value: TValue | null) => {
-        if(!value){
+        const date = readValueAsDate(adapter, value)
+        if(!date){
           return true
         }
         const internalError = validateTime({
@@ -118,7 +119,7 @@ const TimePickerElement = forwardRef(function TimePickerElement<
             disablePast: Boolean(rest.disablePast),
             disableFuture: Boolean(rest.disableFuture),
           },
-          timezone: rest.timezone ?? getTimezone(adapter, value) ?? "default",
+          timezone: rest.timezone ?? getTimezone(adapter, date) ?? "default",
           value,
           adapter,
         });
@@ -146,11 +147,7 @@ const TimePickerElement = forwardRef(function TimePickerElement<
       input:
         typeof transform?.input === "function"
           ? transform.input
-          : (newValue) => {
-              return newValue && typeof newValue === "string"
-                ? (adapter.utils.date(newValue) as unknown as TValue) // need to see if this works for all localization adaptors
-                : newValue;
-            },
+          : (newValue) => readValueAsDate(adapter, newValue),
       output:
         typeof transform?.output === "function"
           ? transform.output

--- a/packages/rhf-mui/src/utils.ts
+++ b/packages/rhf-mui/src/utils.ts
@@ -24,7 +24,7 @@ export function getTimezone<TDate extends PickerValidDate>(
 export function readValueAsDate<TDate extends PickerValidDate>(
   adapter: ReturnType<typeof useLocalizationContext>,
   value: string | null | TDate
-): TDate | null | string {
+): TDate | null {
   if(typeof value === 'string'){
     if(value === ''){
       return null

--- a/packages/rhf-mui/src/utils.ts
+++ b/packages/rhf-mui/src/utils.ts
@@ -24,6 +24,12 @@ export function getTimezone<TDate extends PickerValidDate>(
 export function readValueAsDate<TDate extends PickerValidDate>(
   adapter: ReturnType<typeof useLocalizationContext>,
   value: string | null | TDate
-): TDate | null {
-  return value && typeof value === 'string' ? adapter.utils.date(value) as TDate: null
+): TDate | null | string {
+  if(typeof value === 'string'){
+    if(value === ''){
+      return null
+    }
+    return adapter.utils.date(value) as TDate
+  }
+  return value
 }

--- a/packages/rhf-mui/src/utils.ts
+++ b/packages/rhf-mui/src/utils.ts
@@ -1,3 +1,4 @@
+import { type PickerValidDate } from '@mui/x-date-pickers'
 import {useLocalizationContext} from '@mui/x-date-pickers/internals'
 
 export function propertyExists<X, Y extends PropertyKey>(
@@ -11,11 +12,18 @@ export function propertyExists<X, Y extends PropertyKey>(
   )
 }
 
-export function getTimezone<TDate>(
+export function getTimezone<TDate extends PickerValidDate>(
   adapter: ReturnType<typeof useLocalizationContext>,
   value: TDate
 ): string | null {
   return value == null || !adapter.utils.isValid(value as unknown as Date)
     ? null
     : adapter.utils.getTimezone(value as unknown as Date)
+}
+
+export function readValueAsDate<TDate extends PickerValidDate>(
+  adapter: ReturnType<typeof useLocalizationContext>,
+  value: string | null | TDate
+): TDate | null {
+  return value && typeof value === 'string' ? adapter.utils.date(value) as TDate: null
 }


### PR DESCRIPTION
#320

When date values were provided as strings, internal validation was performed on the string instead of a `Date` object, causing the following components to throw console errors:

- `DatePickerElement`
- `DateTimePickerElement`
- `MobileDatePickerElement`
- `TimePickerElement`

This PR fixes the issue by transforming the value into a `Date` object before performing validation.

### Additional Notes

@dohomi, it might be worth considering changing the default behavior to stop accepting string values for `x-date-pickers`, as MUI's date picker components themselves do not accept strings by default.