### PR TITLE
fix: MultiSelectElement does not allow for options w/ { id: '0' }

### DIFF
--- a/apps/storybook/stories/MultiSelectElement.stories.tsx
+++ b/apps/storybook/stories/MultiSelectElement.stories.tsx
@@ -108,10 +108,10 @@ export const WithCheckbox: Story = {
 }
 
 const objectVals = [
-  {id: 1, name: 'Alpha'},
-  {id: 2, name: 'Beta'},
-  {id: 3, name: 'Celsius'},
-  {id: 4, name: 'Delta'},
+  {id: 0, name: 'Alpha'},
+  {id: 1, name: 'Beta'},
+  {id: 2, name: 'Celsius'},
+  {id: 3, name: 'Delta'},
 ]
 
 export const WithObjectArray: Story = {

--- a/packages/rhf-mui/src/MultiSelectElement.tsx
+++ b/packages/rhf-mui/src/MultiSelectElement.tsx
@@ -261,7 +261,7 @@ const MultiSelectElement = forwardRef(function MultiSelectElement<
         inputRef={handleInputRef}
       >
         {options.map((item) => {
-          const val: string | number = item[itemValue || itemKey] || item
+          const val: string | number = item[itemValue || itemKey] ?? item
           const isChecked = Array.isArray(value)
             ? value.some((v) => v === val)
             : false


### PR DESCRIPTION
I've noticed that with API generated enum types which initialize at index `0`, specifically `MultiSelectElement` tends to misbehave. After some digging I realised that a logical OR operation when rendering chosen `options` would consider the value `'0'` to be falsy, and attempt to render the _whole item_ from `options` instead of just its value. It subsequently causes `[object Object]` to be rendered, allows for selecting said entry more than once without being disabled, and when `showChips` is set to true, it would even outright crash the renderer.

I've changed the operation to be null-coalescing instead, and updated Storybook to advertise the change.

If there's anything I need to clarify, don't hesitate to ask.