### PR TITLE
Fix incorrect RHF dependency by removing references to `../dist/..`

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -23,7 +23,7 @@
     "next": "14.2.10",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-hook-form": "7.48.2",
+    "react-hook-form": "7.54.2",
     "react-hook-form-mui": "portal:../../packages/rhf-mui"
   },
   "devDependencies": {

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -56,7 +56,7 @@
     "date-fns": "3.6.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-hook-form": "7.48.2",
+    "react-hook-form": "7.54.2",
     "storybook": "8.0.10",
     "typescript": "5.5.3",
     "vite": "^5.2.14"

--- a/packages/rhf-mui/package.json
+++ b/packages/rhf-mui/package.json
@@ -74,7 +74,7 @@
     "react": "18.3.1",
     "react-docgen-typescript-loader": "^3.7.2",
     "react-dom": "18.3.1",
-    "react-hook-form": "7.48.2",
+    "react-hook-form": "7.54.2",
     "release": "^6.3.1",
     "tsup": "^6.1.2",
     "typescript": "5.5.3"

--- a/packages/rhf-mui/src/DateTimePickerElement.tsx
+++ b/packages/rhf-mui/src/DateTimePickerElement.tsx
@@ -12,12 +12,12 @@ import {
   Control,
   FieldError,
   FieldPath,
+  FieldValues,
   PathValue,
   useController,
   UseControllerProps,
 } from 'react-hook-form'
 import {TextFieldProps, useForkRef} from '@mui/material'
-import {FieldValues} from 'react-hook-form/dist/types/fields'
 import {useFormError} from './FormErrorProvider'
 import {forwardRef, ReactNode, Ref, RefAttributes} from 'react'
 import {defaultErrorMessages} from './messages/DateTimePicker'

--- a/packages/rhf-mui/src/FormContainer.tsx
+++ b/packages/rhf-mui/src/FormContainer.tsx
@@ -1,5 +1,6 @@
 import {FormEventHandler, FormHTMLAttributes, PropsWithChildren} from 'react'
 import {
+  FieldValues,
   FormProvider,
   SubmitErrorHandler,
   SubmitHandler,
@@ -7,7 +8,6 @@ import {
   UseFormProps,
   UseFormReturn,
 } from 'react-hook-form'
-import {FieldValues} from 'react-hook-form/dist/types/fields'
 
 export type FormContainerProps<T extends FieldValues = FieldValues> =
   PropsWithChildren<

--- a/yarn.lock
+++ b/yarn.lock
@@ -9707,7 +9707,7 @@ __metadata:
     next: "npm:14.2.10"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
-    react-hook-form: "npm:7.48.2"
+    react-hook-form: "npm:7.54.2"
     react-hook-form-mui: "portal:../../packages/rhf-mui"
     typescript: "npm:5.5.3"
   languageName: unknown
@@ -10835,7 +10835,7 @@ __metadata:
     react: "npm:18.3.1"
     react-docgen-typescript-loader: "npm:^3.7.2"
     react-dom: "npm:18.3.1"
-    react-hook-form: "npm:7.48.2"
+    react-hook-form: "npm:7.54.2"
     release: "npm:^6.3.1"
     tsup: "npm:^6.1.2"
     typescript: "npm:5.5.3"
@@ -10853,12 +10853,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-hook-form@npm:7.48.2":
-  version: 7.48.2
-  resolution: "react-hook-form@npm:7.48.2"
+"react-hook-form@npm:7.54.2":
+  version: 7.54.2
+  resolution: "react-hook-form@npm:7.54.2"
   peerDependencies:
-    react: ^16.8.0 || ^17 || ^18
-  checksum: 10/6cb494f359675e78c14c49a33d1c568df1a03db4c750eab18d6554e622fd64e04195c57efa138db03f8988587d132c57d2a7f5f3dd9157be996cc9acd4362170
+    react: ^16.8.0 || ^17 || ^18 || ^19
+  checksum: 10/b156d15b6246c76d0275e5722d9056014693e014d0e3dec06e44bf2672ee549aaba4366de5144d18c4cab29e631f3b2b84269d4fd5727ca17aad9b970fde6960
   languageName: node
   linkType: hard
 
@@ -11316,7 +11316,7 @@ __metadata:
     date-fns: "npm:3.6.0"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
-    react-hook-form: "npm:7.48.2"
+    react-hook-form: "npm:7.54.2"
     react-hook-form-mui: "portal:../../packages/rhf-mui"
     storybook: "npm:8.0.10"
     typescript: "npm:5.5.3"


### PR DESCRIPTION
<img width="1355" alt="image" src="https://github.com/user-attachments/assets/62701702-df8f-4a15-b0c3-2b9fa9d6f0e4" />

For unknown reason, the import subpath from `react-hook-form/dist/types/fields` failed to resolve in the built package but not in the source code. I've tried checking using both RHF@7.48.2 and @7.54.2 but both seems to be problematic.

To fix this, the import path is changed to simply point to `react-hook-form`