### PR TITLE
Fix "key" prop warning is being spread on AutocompleteElement

### DIFF
--- a/packages/rhf-mui/src/AutocompleteElement.tsx
+++ b/packages/rhf-mui/src/AutocompleteElement.tsx
@@ -282,7 +282,7 @@ const AutocompleteElement = forwardRef(function AutocompleteElement<
         (showCheckbox
           ? (props, option, {selected}) => {
               return (
-                <li {...props}>
+                <li {...props} key={props.key}>
                   <Checkbox sx={{marginRight: 1}} checked={selected} />
                   {getOptionLabel(option)}
                 </li>


### PR DESCRIPTION
```js
? (props, option, {selected}) => {
              return (
                <li {...props} key={props.key}>
                  <Checkbox sx={{marginRight: 1}} checked={selected} />
                  {getOptionLabel(option)}
                </li>
```

the props contain key property, which is the label by default as stated [here](https://mui.com/material-ui/api/autocomplete/#autocomplete-prop-getOptionKey)

related issue: https://github.com/dohomi/react-hook-form-mui/issues/247