### PR TITLE
Add small gap to MultiSelectElement

### DIFF
--- a/packages/rhf-mui/src/MultiSelectElement.tsx
+++ b/packages/rhf-mui/src/MultiSelectElement.tsx
@@ -224,7 +224,7 @@ const MultiSelectElement = forwardRef(function MultiSelectElement<
             ? rest.renderValue
             : showChips
               ? (selected) => (
-                  <div style={{display: 'flex', flexWrap: 'wrap'}}>
+                  <div style={{display: 'flex', flexWrap: 'wrap', gap: '4px'}}>
                     {(preserveOrder
                       ? options.filter((option) =>
                           (selected as any[]).includes(option)


### PR DESCRIPTION
https://react-hook-form-material-ui.vercel.app/?path=/docs/select-multiselectelement--docs

**before**:
![image](https://github.com/user-attachments/assets/0c8ebcb3-d108-4bdc-a361-fae3546a806d)

**after**:
![image](https://github.com/user-attachments/assets/5a36b5aa-4397-48a8-a5b1-3d05513f5251)

😅