### PR TITLE
Revert "edit package.json"

### DIFF
--- a/packages/rhf-mui/package.json
+++ b/packages/rhf-mui/package.json
@@ -57,7 +57,7 @@
   "peerDependencies": {
     "@mui/icons-material": ">= 5.x <8",
     "@mui/material": ">= 5.x <8",
-    "@mui/x-date-pickers": ">=7.17.0 <9",
+    "@mui/x-date-pickers": ">=7.17.0 <8",
     "react": ">=17 <20",
     "react-hook-form": ">=7.33.1"
   },


### PR DESCRIPTION
Reverts dohomi/react-hook-form-mui#362

Apologies -- we hadn't fixed the package version incompatibilities yet. This was just our initial commit. We're going to follow up with the fixes in place