### PR TITLE
fix: preserve free-form text in AutocompleteElement

### DIFF
--- a/apps/storybook/stories/AutocompleteElement.stories.tsx
+++ b/apps/storybook/stories/AutocompleteElement.stories.tsx
@@ -158,6 +158,29 @@ export const MatchIdMulti = {
   },
 }
 
+export const FreeSolo: Story = {
+  args: {
+    label: 'Free Solo',
+    name: 'free-solo',
+    options,
+    autocompleteProps: {
+      freeSolo: true,
+    },
+  },
+}
+
+export const FreeSoloMultiple: Story = {
+  args: {
+    label: 'Free Solo Multiple',
+    name: 'free-solo-multi',
+    options,
+    multiple: true,
+    autocompleteProps: {
+      freeSolo: true,
+    },
+  },
+}
+
 export const CustomInput = {
   args: {
     name: 'custom-input',

--- a/packages/rhf-mui/src/AutocompleteElement.tsx
+++ b/packages/rhf-mui/src/AutocompleteElement.tsx
@@ -203,9 +203,12 @@ const AutocompleteElement = forwardRef(function AutocompleteElement<
               return (
                 multiple
                   ? (Array.isArray(newValue) ? newValue : []).map(
-                      matchOptionByValue
+                      (v) =>
+                        matchOptionByValue(v) ??
+                        (autocompleteProps?.freeSolo ? v : undefined)
                     )
-                  : matchOptionByValue(newValue) ?? null
+                  : matchOptionByValue(newValue) ??
+                    (autocompleteProps?.freeSolo ? newValue : null)
               ) as AutocompleteValue<
                 TValue,
                 Multiple,


### PR DESCRIPTION
`freeSolo` text (free text) was being discarded from the AutoComplete element.

- The default input transform in `AutocompleteElement` always matches the form value against the options list `matchOptionByValue()`, returning `null` when no match is found even when `freeSolo` is enabled. This causes user-typed free text to be silently discarded.
- When `freeSolo` is true, the transform now falls back to the raw value instead of `null`, for both single and multiple modes.

Also added the free solo single/multi to storybook for testing